### PR TITLE
add tx override params to write transaction helper

### DIFF
--- a/Assets/Treasure/TDK/Runtime/API/Transaction.cs
+++ b/Assets/Treasure/TDK/Runtime/API/Transaction.cs
@@ -14,11 +14,20 @@ namespace Treasure
     }
 
     [Serializable]
-    internal class WriteTransactionBody
+    public class WriteTransactionBody
     {
+        public struct TransactionOverrides
+        {
+            public string value;
+            public string gas;
+            public string maxFeePerGas;
+            public string maxPriorityFeePerGas;
+        }
+
         public string address;
         public string functionName;
         public object[] args;
+        public TransactionOverrides txOverrides;
     }
 
     public partial class API
@@ -29,15 +38,20 @@ namespace Treasure
             return JsonConvert.DeserializeObject<Transaction>(response);
         }
 
+        public async Task<Transaction> WriteTransaction(WriteTransactionBody body)
+        {
+            var response = await Post("/transactions", JsonConvert.SerializeObject(body));
+            return JsonConvert.DeserializeObject<Transaction>(response);
+        }
+
         public async Task<Transaction> WriteTransaction(string address, string functionName, object[] args)
         {
-            var response = await Post("/transactions", JsonConvert.SerializeObject(new WriteTransactionBody()
+            return await WriteTransaction(new WriteTransactionBody()
             {
                 address = address,
                 functionName = functionName,
                 args = args,
-            }));
-            return JsonConvert.DeserializeObject<Transaction>(response);
+            });
         }
 
         public async Task<Transaction> WriteTransaction(Contract contract, string functionName, object[] args)


### PR DESCRIPTION
**NOTE:** Do not merge until API changes are deployed to production and PR is marked as ready

- Adds support for `txOverrides` param in transaction write helper method