### PR TITLE
update login calls for thirdweb v5 format; deprecate old method

### DIFF
--- a/Assets/Treasure/TDK/Runtime/API/Auth.cs
+++ b/Assets/Treasure/TDK/Runtime/API/Auth.cs
@@ -41,13 +41,8 @@ namespace Treasure
     [Serializable]
     public struct LogInBody
     {
-        public struct Payload
-        {
-            public AuthPayload payload;
-            public string signature;
-        }
-
-        public Payload payload;
+        public AuthPayload payload;
+        public string signature;
     }
 
     [Serializable]
@@ -66,6 +61,7 @@ namespace Treasure
 
     public partial class API
     {
+        [Obsolete("GetAuthPayload is deprecated. Use GetLoginPayload.")]
         public async Task<AuthPayload> GetAuthPayload(string address, string chainId)
         {
             var response = await Post("/auth/payload", JsonConvert.SerializeObject(new GetAuthPayloadBody()
@@ -76,15 +72,18 @@ namespace Treasure
             return JsonConvert.DeserializeObject<GetAuthPayloadResponse>(response).payload;
         }
 
+        public async Task<AuthPayload> GetLoginPayload(string address)
+        {
+            var response = await Get($"/login/payload?address={address}");
+            return JsonConvert.DeserializeObject<AuthPayload>(response);
+        }
+
         public async Task<string> LogIn(AuthPayload payload, string signature)
         {
-            var response = await Post("/auth/login", JsonConvert.SerializeObject(new LogInBody()
+            var response = await Post("/login", JsonConvert.SerializeObject(new LogInBody()
             {
-                payload = new LogInBody.Payload()
-                {
-                    payload = payload,
-                    signature = signature,
-                }
+                payload = payload,
+                signature = signature,
             }));
             return JsonConvert.DeserializeObject<LogInResponse>(response).token;
         }

--- a/Assets/Treasure/TDK/Runtime/Identity/TDK.Identity.cs
+++ b/Assets/Treasure/TDK/Runtime/Identity/TDK.Identity.cs
@@ -168,7 +168,7 @@ namespace Treasure
 
             // Create auth token
             TDKLogger.Log("Generating auth payload");
-            var payload = await TDK.API.GetAuthPayload(address, chainId.ToString());
+            var payload = await TDK.API.GetLoginPayload(address);
 
             TDKLogger.Log("Generating auth signature");
             var signature = await GenerateSignature(payload);


### PR DESCRIPTION
**NOTE:** Do not merge until API changes are deployed to production and PR is marked as ready

- Updates login helpers and payloads to match new formats compatible with the Thirdweb SDK v5 Auth package
- Deprecates obsolete auth helper