### PR TITLE
add connect flag for silent login

### DIFF
--- a/Assets/Treasure/TDK/Runtime/Connect/UI/TDKConnectUIManager.cs
+++ b/Assets/Treasure/TDK/Runtime/Connect/UI/TDKConnectUIManager.cs
@@ -23,7 +23,7 @@ namespace Treasure
         [Header("Test buttons")]
         [SerializeField] private Button switchThemeButton;
         [SerializeField] private Button switchSceneButton;
-        [SerializeField] private ScreenOrientation currentOriantation;       
+        [SerializeField] private ScreenOrientation currentOriantation;
 
         private ModalBase currentModalOpended;
 
@@ -31,13 +31,14 @@ namespace Treasure
 
         private string _address;
         private string _email;
+        private bool _isSilentLogin = false;
         private bool useSmartWallets = true;
         private ChainData _currentChainData;
 
         private void Awake()
         {
             if (Instance == null)
-                Instance = this;          
+                Instance = this;
         }
 
         private void Start()
@@ -61,6 +62,11 @@ namespace Treasure
             {
                 ShowAccountModal();
             });
+        }
+
+        public bool IsSilentLogin
+        {
+            get { return _isSilentLogin; }
         }
 
         #region test code
@@ -134,9 +140,9 @@ namespace Treasure
                 currentModalOpended.Hide();
 
             currentModalOpended = logedInHolder;
-            logedInHolder.Show();       
+            logedInHolder.Show();
 
-            TDK.Analytics.TrackCustomEvent(AnalyticsConstants.EVT_TREASURECONNECT_UI_ACCOUNT);  
+            TDK.Analytics.TrackCustomEvent(AnalyticsConstants.EVT_TREASURECONNECT_UI_ACCOUNT);
         }
 
         public void LogOut()
@@ -157,9 +163,10 @@ namespace Treasure
         #endregion
 
         #region Connecting
-        public async Task<bool> ConnectEmail(string email)
+        public async Task<bool> ConnectEmail(string email, bool isSilentLogin = false)
         {
             _email = email;
+            _isSilentLogin = isSilentLogin;
             var wc = useSmartWallets
                 ? new WalletConnection(
                     provider: WalletProvider.SmartWallet,

--- a/Assets/Treasure/TDK/Runtime/Connect/UI/TDKEmbeddedWalletUI.cs
+++ b/Assets/Treasure/TDK/Runtime/Connect/UI/TDKEmbeddedWalletUI.cs
@@ -10,6 +10,8 @@ using UnityEngine.Events;
 
 namespace Treasure
 {
+    public class TDKSilentLoginException : Exception { }
+
     public class TDKEmbeddedWalletUI : InAppWalletUI
     {
         [Space]
@@ -79,6 +81,12 @@ namespace Treasure
             }
             catch (Exception e)
             {
+                if (TDKConnectUIManager.Instance.IsSilentLogin)
+                {
+                    ThirdwebDebug.Log($"Could not recreate user automatically, skipping silent login");
+                    throw new TDKSilentLoginException();
+                }
+
                 ThirdwebDebug.Log($"Could not recreate user automatically, proceeding with auth: {e.Message}");
             }
 


### PR DESCRIPTION
Adds ability to mark a `ConnectEmail` call as a silent login to skip the automatic OTP send. Consumer will need to wrap the call in `try/catch` and ignore `TDKSilentLoginException` errors.