### PR TITLE
Skip custom logging logic when app is shutting down

### DIFF
--- a/Assets/Treasure/TDK-Private/Editor/TDKPackagerCore.cs
+++ b/Assets/Treasure/TDK-Private/Editor/TDKPackagerCore.cs
@@ -40,7 +40,6 @@ namespace Treasure
                 "Assets/Treasure/TDK/Runtime/Utils",
 
                 // Resources
-                "Assets/Treasure/TDK/Resources/TDKConnectSettings.asset",
                 "Assets/Treasure/TDK/Resources/TDKConnectThemeData.asset",
 
                 "Assets/package.json",

--- a/Assets/Treasure/TDK-Private/Editor/TDKPackagerFull.cs
+++ b/Assets/Treasure/TDK-Private/Editor/TDKPackagerFull.cs
@@ -28,7 +28,6 @@ namespace Treasure
                 "Assets/Treasure/TDK/ConnectInternal",
                 "Assets/Treasure/TDK/ConnectPrefabs",
                 "Assets/Treasure/TDK/Editor",
-                "Assets/Treasure/TDK/Resources/TDKConnectSettings.asset",
                 "Assets/Treasure/TDK/Resources/TDKConnectThemeData.asset",
                 "Assets/Treasure/TDK/Runtime",
 

--- a/Assets/Treasure/TDK/Runtime/Infrastructure/TDKBaseService.cs
+++ b/Assets/Treasure/TDK/Runtime/Infrastructure/TDKBaseService.cs
@@ -6,6 +6,8 @@ namespace Treasure
     // why do we need empty game objects for services? it could be independent from unity
     public class TDKBaseService : MonoBehaviour
     {
+        protected bool appIsQuitting = false;
+
         public virtual void Awake()
         {
             DontDestroyOnLoad(this);

--- a/Assets/Treasure/TDK/Runtime/Infrastructure/TDKLogger.cs
+++ b/Assets/Treasure/TDK/Runtime/Infrastructure/TDKLogger.cs
@@ -7,8 +7,6 @@ namespace Treasure
     {
         public static Action<string> ExternalLogCallback;
 
-        public static bool quitting = false;
-
         public static void LogDebug(string message)
         {
             LogByLevel(TDKConfig.LoggerLevelValue.DEBUG, message);
@@ -36,7 +34,7 @@ namespace Treasure
         }
 
         private static void LogByLevel(TDKConfig.LoggerLevelValue loggerLevelValue, string message) {
-            if (quitting) {
+            if (TDK.Instance.appIsQuitting) {
                 Debug.Log($"[{loggerLevelValue}] {message}");
                 return;
             }

--- a/Assets/Treasure/TDK/Runtime/Infrastructure/TDKLogger.cs
+++ b/Assets/Treasure/TDK/Runtime/Infrastructure/TDKLogger.cs
@@ -1,7 +1,5 @@
 using UnityEngine;
 using System;
-using System.Collections;
-using System.Diagnostics;
 
 namespace Treasure
 {
@@ -39,7 +37,7 @@ namespace Treasure
 
         private static void LogByLevel(TDKConfig.LoggerLevelValue loggerLevelValue, string message) {
             if (quitting) {
-                UnityEngine.Debug.Log($"[{loggerLevelValue}] {message}");
+                Debug.Log($"[{loggerLevelValue}] {message}");
                 return;
             }
             if (TDK.Instance.AppConfig.LoggerLevel > loggerLevelValue) {
@@ -50,13 +48,13 @@ namespace Treasure
             switch (loggerLevelValue)
             {
                 case TDKConfig.LoggerLevelValue.ERROR:
-                    UnityEngine.Debug.LogError(message);
+                    Debug.LogError(message);
                     break;
                 case TDKConfig.LoggerLevelValue.WARNING:
-                    UnityEngine.Debug.LogWarning(message);
+                    Debug.LogWarning(message);
                     break;
                 default:
-                    UnityEngine.Debug.Log(message);
+                    Debug.Log(message);
                     break;
             }
             #else
@@ -67,7 +65,7 @@ namespace Treasure
         private static void LogMessageInternal(string message)
         {
             try {
-                UnityEngine.Debug.Log(string.Format("[{0}] {1}", Time.realtimeSinceStartup, message));
+                Debug.Log(string.Format("[{0}] {1}", Time.realtimeSinceStartup, message));
             } catch {
                 // no-op
             }

--- a/Assets/Treasure/TDK/Runtime/Infrastructure/TDKLogger.cs
+++ b/Assets/Treasure/TDK/Runtime/Infrastructure/TDKLogger.cs
@@ -9,6 +9,8 @@ namespace Treasure
     {
         public static Action<string> ExternalLogCallback;
 
+        public static bool quitting = false;
+
         public static void LogDebug(string message)
         {
             LogByLevel(TDKConfig.LoggerLevelValue.DEBUG, message);
@@ -36,6 +38,10 @@ namespace Treasure
         }
 
         private static void LogByLevel(TDKConfig.LoggerLevelValue loggerLevelValue, string message) {
+            if (quitting) {
+                UnityEngine.Debug.Log($"[{loggerLevelValue}] {message}");
+                return;
+            }
             if (TDK.Instance.AppConfig.LoggerLevel > loggerLevelValue) {
                 return;
             }

--- a/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/AnalyticsConstants.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/AnalyticsConstants.cs
@@ -5,8 +5,6 @@ namespace Treasure
         // event cache values
         public const int MAX_CACHE_EVENT_COUNT = 10;
         public const int MAX_CACHE_SIZE_KB = 64;
-        public const int MEMORY_CACHE_FLUSH_TIME_SECONDS = 10;
-        public const int DISK_CACHE_FLUSH_TIME_SECONDS = 60;
         
         // persistent store values
         public const string PERSISTENT_DIRECTORY_NAME = "AnalyticsStore";

--- a/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.Cache.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.Cache.cs
@@ -72,7 +72,7 @@ namespace Treasure
                         break;
                     }
                 }
-                await Task.Delay(TimeSpan.FromSeconds(AnalyticsConstants.DISK_CACHE_FLUSH_TIME_SECONDS));
+                await Task.Delay(TimeSpan.FromSeconds(TDK.Instance.AppConfig.AnalyticsDiscFlushFrequencySeconds));
             }
         }
 
@@ -89,8 +89,8 @@ namespace Treasure
         private void ResetFlushTimer()
         {
             _flushCacheTimer?.Change(
-                TimeSpan.FromSeconds(AnalyticsConstants.MEMORY_CACHE_FLUSH_TIME_SECONDS),
-                TimeSpan.FromSeconds(AnalyticsConstants.MEMORY_CACHE_FLUSH_TIME_SECONDS)
+                TimeSpan.FromSeconds(TDK.Instance.AppConfig.AnalyticsMemoryFlushFrequencySeconds),
+                TimeSpan.FromSeconds(TDK.Instance.AppConfig.AnalyticsMemoryFlushFrequencySeconds)
             );
         }
 

--- a/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.Cache.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.Cache.cs
@@ -105,8 +105,13 @@ namespace Treasure
 
             if(memoryCacheCopy.Count > 0)
             {
-                // Send the batch of events for io
-                var success = await SendEventBatch(memoryCacheCopy);
+                var success = false;
+
+                if(!appIsQuitting)
+                {
+                    // Send the batch of events for io
+                    success = await SendEventBatch(memoryCacheCopy);
+                }
 
                 // If the request failed, persist the payload to disk in a separate task
                 if(!success)

--- a/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.cs
@@ -28,6 +28,7 @@ namespace Treasure
 #if !UNITY_WEBGL
         void OnApplicationQuit()
         {
+            appIsQuitting = true;
             TerminateCacheFlushing();
         }
 #endif

--- a/Assets/Treasure/TDK/Runtime/TDK.cs
+++ b/Assets/Treasure/TDK/Runtime/TDK.cs
@@ -17,13 +17,15 @@ namespace Treasure
 
         public TDKConfig AppConfig { get; private set; }
 
+        internal bool appIsQuitting = false;
+
         void OnApplicationPause(bool isPaused)
         {
             Analytics?.OnApplicationPause_Analytics(isPaused);
         }
 
         void OnApplicationQuit() {
-            TDKLogger.quitting = true;
+            appIsQuitting = true;
         }
 
         public static TDK Instance

--- a/Assets/Treasure/TDK/Runtime/TDK.cs
+++ b/Assets/Treasure/TDK/Runtime/TDK.cs
@@ -22,6 +22,10 @@ namespace Treasure
             Analytics?.OnApplicationPause_Analytics(isPaused);
         }
 
+        void OnApplicationQuit() {
+            TDKLogger.quitting = true;
+        }
+
         public static TDK Instance
         {
             get

--- a/Assets/Treasure/TDK/Runtime/TDKConfig.cs
+++ b/Assets/Treasure/TDK/Runtime/TDKConfig.cs
@@ -53,6 +53,8 @@ namespace Treasure
         {
             public string _devApiUrl = "https://darkmatter.spellcaster.lol/ingress";
             public string _prodApiUrl = "https://darkmatter.treasure.lol/ingress";
+            public int _memoryFlushFrequencySeconds = 10;
+            public int _diskFlushFrequencySeconds = 30;
         }
 
         public enum Env { DEV, PROD }
@@ -95,7 +97,8 @@ namespace Treasure
         public int SessionMinDurationLeftSec => _connect._sessionMinDurationLeftSec;
 
         public string AnalyticsApiUrl => Environment == Env.DEV ? _analytics._devApiUrl : _analytics._prodApiUrl;
-
+        public int AnalyticsMemoryFlushFrequencySeconds => _analytics._memoryFlushFrequencySeconds;
+        public int AnalyticsDiscFlushFrequencySeconds => _analytics._diskFlushFrequencySeconds;
 
         public LoggerLevelValue LoggerLevel
         {
@@ -249,6 +252,8 @@ namespace Treasure
         {
             public string devApiUrl;
             public string prodApiUrl;
+            public int memoryFlushFrequencySeconds;
+            public int diskFlushFrequencySeconds;
         }
 
         [Serializable]


### PR DESCRIPTION
Reported by Shep in [this slack thread](https://treasuredao.slack.com/archives/C076KQXT4DQ/p1723644241532409)

Context:
- When stopping play mode with events still in the analytics service cache, those events will attempt to be flushed.
- Since the app is closing, all references to unity game object will become null, which include `TDK.Instance` and `TDKMainThreadDispatcher.Instance`.
- When flushing the events there are log calls (before and after the flush), which internally call `TDKLogger.LogByLevel`
- `TDKLogger.LogByLevel` references `TDK.Instance` and `TDKMainThreadDispatcher.Instance` to work, which are both already being unloaded (null), and in turn tries to create them again, which seems to cause those two objects to appear and stay in the scene hierarchy even after exiting play mode.
- (Depending on the timing, this might also mean that flushed events are not sent on app close.)