### PR TITLE
Make AppConfig static. Tweak singleton handling

### DIFF
--- a/Assets/Treasure/Example/Scripts/MagicswapUI.cs
+++ b/Assets/Treasure/Example/Scripts/MagicswapUI.cs
@@ -122,7 +122,7 @@ public class MagicswapUI : MonoBehaviour
             InfoText.text = "Must get pool details before approving LP!";
             return;
         }
-        var callTargets = await TDK.Instance.AppConfig.GetCallTargets();
+        var callTargets = await TDK.AppConfig.GetCallTargets();
         if (!callTargets.Contains(magicswapPool.id)) {
             InfoText.text = "`callTargets` in TDKConfig must include the pool id!";
             InfoText.text += "\nPool id: " + magicswapPool.id;

--- a/Assets/Treasure/TDK/Runtime/API/Magicswap.cs
+++ b/Assets/Treasure/TDK/Runtime/API/Magicswap.cs
@@ -188,7 +188,7 @@ namespace Treasure
         }
 
         public async Task<Transaction> Swap(SwapBody swapBody) {
-            swapBody.backendWallet ??= await TDK.Instance.AppConfig.GetBackendWallet();
+            swapBody.backendWallet ??= await TDK.AppConfig.GetBackendWallet();
             var body = JsonConvert.SerializeObject(swapBody, new JsonSerializerSettings {
                 NullValueHandling = NullValueHandling.Ignore
             });
@@ -199,7 +199,7 @@ namespace Treasure
         }
 
         public async Task<Transaction> AddLiquidity(string poolId, AddLiquidityBody addLiquidityBody) {
-            addLiquidityBody.backendWallet ??= await TDK.Instance.AppConfig.GetBackendWallet();
+            addLiquidityBody.backendWallet ??= await TDK.AppConfig.GetBackendWallet();
             var body = JsonConvert.SerializeObject(addLiquidityBody, new JsonSerializerSettings {
                 NullValueHandling = NullValueHandling.Ignore
             });
@@ -210,7 +210,7 @@ namespace Treasure
         }
 
         public async Task<Transaction> RemoveLiquidity(string poolId, RemoveLiquidityBody removeLiquidityBody) {
-            removeLiquidityBody.backendWallet ??= await TDK.Instance.AppConfig.GetBackendWallet();
+            removeLiquidityBody.backendWallet ??= await TDK.AppConfig.GetBackendWallet();
             var body = JsonConvert.SerializeObject(removeLiquidityBody, new JsonSerializerSettings {
                 NullValueHandling = NullValueHandling.Ignore
             });

--- a/Assets/Treasure/TDK/Runtime/API/TDK.API.cs
+++ b/Assets/Treasure/TDK/Runtime/API/TDK.API.cs
@@ -30,14 +30,14 @@ namespace Treasure
             // Create request
             var req = new UnityWebRequest
             {
-                url = TDK.Instance.AppConfig.TDKApiUrl + path,
+                url = TDK.AppConfig.TDKApiUrl + path,
                 method = "GET",
                 downloadHandler = new DownloadHandlerBuffer()
             };
             req.SetRequestHeader("Content-Type", "application/json");
 
             // Set the API key header
-            req.SetRequestHeader("x-api-key", TDK.Instance.AppConfig.ApiKey);
+            req.SetRequestHeader("x-api-key", TDK.AppConfig.ApiKey);
 
             // Set chain ID with override option
             if (overrides.HasValue && overrides.Value.chainId > 0)
@@ -78,7 +78,7 @@ namespace Treasure
             // Create request
             var req = new UnityWebRequest
             {
-                url = TDK.Instance.AppConfig.TDKApiUrl + path,
+                url = TDK.AppConfig.TDKApiUrl + path,
                 method = "POST",
                 uploadHandler = new UploadHandlerRaw(Encoding.UTF8.GetBytes(body)),
                 downloadHandler = new DownloadHandlerBuffer()
@@ -86,7 +86,7 @@ namespace Treasure
             req.SetRequestHeader("Content-Type", "application/json");
 
             // Set the API key header
-            req.SetRequestHeader("x-api-key", TDK.Instance.AppConfig.ApiKey);
+            req.SetRequestHeader("x-api-key", TDK.AppConfig.ApiKey);
 
             // Set chain ID with override option
             if (overrides.HasValue && overrides.Value.chainId > 0)

--- a/Assets/Treasure/TDK/Runtime/Connect/TDK.Connect.cs
+++ b/Assets/Treasure/TDK/Runtime/Connect/TDK.Connect.cs
@@ -66,7 +66,7 @@ namespace Treasure
                 var isConnected = await IsWalletConnected();
                 if (Utils.IsWebGLBuild() && !isConnected)
                 {
-                    _chainId = TDK.Instance.AppConfig.DefaultChainId;
+                    _chainId = TDK.AppConfig.DefaultChainId;
                 }
                 else
                 {

--- a/Assets/Treasure/TDK/Runtime/Connect/UI/HeaderLogo.cs
+++ b/Assets/Treasure/TDK/Runtime/Connect/UI/HeaderLogo.cs
@@ -16,8 +16,8 @@ namespace Treasure
 
         private void Start()
         {
-            nameText.text = TDK.Instance.AppConfig.CartridgeName;
-            ApplySprite(TDK.Instance.AppConfig.CartridgeIcon);
+            nameText.text = TDK.AppConfig.CartridgeName;
+            ApplySprite(TDK.AppConfig.CartridgeIcon);
         }
 
         private void ApplySprite(Sprite sprite)

--- a/Assets/Treasure/TDK/Runtime/Identity/TDK.Identity.cs
+++ b/Assets/Treasure/TDK/Runtime/Identity/TDK.Identity.cs
@@ -79,7 +79,7 @@ namespace Treasure
         private async Task CreateSessionKey(string backendWallet, List<string> callTargets, BigInteger nativeTokenLimitPerTransaction)
         {
             var permissionStartTimestamp = (decimal)Utils.GetUnixTimeStampNow() - 60 * 60;
-            var permissionEndTimestamp = (decimal)(Utils.GetUnixTimeStampNow() + TDK.Instance.AppConfig.SessionDurationSec);
+            var permissionEndTimestamp = (decimal)(Utils.GetUnixTimeStampNow() + TDK.AppConfig.SessionDurationSec);
             await TDKServiceLocator.GetService<TDKThirdwebService>().Wallet.CreateSessionKey(
                 signerAddress: backendWallet,
                 approvedTargets: callTargets,
@@ -110,7 +110,7 @@ namespace Treasure
             var requestedCallTargets = callTargets.Select(callTarget => callTarget.ToLowerInvariant());
             var signerApprovedTargets = signer.approvedTargets.Select(approvedTarget => approvedTarget.ToLowerInvariant());
             var nowDate = Utils.GetUnixTimeStampNow();
-            var minEndDate = Utils.GetUnixTimeStampNow() + TDK.Instance.AppConfig.SessionMinDurationLeftSec;
+            var minEndDate = Utils.GetUnixTimeStampNow() + TDK.AppConfig.SessionMinDurationLeftSec;
             var maxEndDate = Utils.GetUnixTimeStampIn10Years();
             return
                 // Expected backend wallet is signer
@@ -146,12 +146,12 @@ namespace Treasure
                     chainId = chainId
                 });
 
-                var backendWallet = await TDK.Instance.AppConfig.GetBackendWallet();
-                var callTargets = await TDK.Instance.AppConfig.GetCallTargets();
+                var backendWallet = await TDK.AppConfig.GetBackendWallet();
+                var callTargets = await TDK.AppConfig.GetCallTargets();
                 var requiresSession = !string.IsNullOrEmpty(backendWallet) && callTargets.Count > 0;
                 if (requiresSession)
                 {
-                    var nativeTokenLimitPerTransaction = await TDK.Instance.AppConfig.GetNativeTokenLimitPerTransaction();
+                    var nativeTokenLimitPerTransaction = await TDK.AppConfig.GetNativeTokenLimitPerTransaction();
 
                     // Check if any active signers match the call targets
                     var hasActiveSession = user.allActiveSigners.Any((signer) =>
@@ -215,9 +215,9 @@ namespace Treasure
                 await TDK.Connect.SetChainId(chainId);
             }
 
-            var backendWallet = await TDK.Instance.AppConfig.GetBackendWallet();
-            var callTargets = await TDK.Instance.AppConfig.GetCallTargets();
-            var nativeTokenLimitPerTransaction = await TDK.Instance.AppConfig.GetNativeTokenLimitPerTransaction();
+            var backendWallet = await TDK.AppConfig.GetBackendWallet();
+            var callTargets = await TDK.AppConfig.GetCallTargets();
+            var nativeTokenLimitPerTransaction = await TDK.AppConfig.GetNativeTokenLimitPerTransaction();
             var requiresSession = !string.IsNullOrEmpty(backendWallet) && callTargets.Count > 0;
             var didCreateSession = false;
 

--- a/Assets/Treasure/TDK/Runtime/Infrastructure/TDKBaseService.cs
+++ b/Assets/Treasure/TDK/Runtime/Infrastructure/TDKBaseService.cs
@@ -6,8 +6,6 @@ namespace Treasure
     // why do we need empty game objects for services? it could be independent from unity
     public class TDKBaseService : MonoBehaviour
     {
-        protected bool appIsQuitting = false;
-
         public virtual void Awake()
         {
             DontDestroyOnLoad(this);

--- a/Assets/Treasure/TDK/Runtime/Infrastructure/TDKLogger.cs
+++ b/Assets/Treasure/TDK/Runtime/Infrastructure/TDKLogger.cs
@@ -34,14 +34,10 @@ namespace Treasure
         }
 
         private static void LogByLevel(TDKConfig.LoggerLevelValue loggerLevelValue, string message) {
-            if (TDK.Instance.appIsQuitting) {
-                Debug.Log($"[{loggerLevelValue}] {message}");
+            if (TDK.AppConfig.LoggerLevel > loggerLevelValue) {
                 return;
             }
-            if (TDK.Instance.AppConfig.LoggerLevel > loggerLevelValue) {
-                return;
-            }
-            TDKMainThreadDispatcher.Instance.Enqueue(() => ExternalLogCallback?.Invoke(message));
+            TDKMainThreadDispatcher.Enqueue(() => ExternalLogCallback?.Invoke(message));
             #if UNITY_EDITOR
             switch (loggerLevelValue)
             {
@@ -56,7 +52,7 @@ namespace Treasure
                     break;
             }
             #else
-            TDKMainThreadDispatcher.Instance.Enqueue(() => LogMessageInternal(message));
+            TDKMainThreadDispatcher.Enqueue(() => LogMessageInternal(message));
             #endif
         }
 

--- a/Assets/Treasure/TDK/Runtime/Infrastructure/TDKMainThreadDispatcher.cs
+++ b/Assets/Treasure/TDK/Runtime/Infrastructure/TDKMainThreadDispatcher.cs
@@ -22,26 +22,20 @@ namespace Treasure
             }
         }
 
-        public static TDKMainThreadDispatcher Instance
-        {
-            get
-            {
-                if(_instance == null)
+        // create a GameObject to grab stuff from the queue
+        public static void StartProcessing() {
+            if (_instance == null) {
+                _instance = GameObject.FindObjectOfType(typeof(TDKMainThreadDispatcher)) as TDKMainThreadDispatcher;
+                
+                if (_instance == null)
                 {
-                    _instance = GameObject.FindObjectOfType(typeof(TDKMainThreadDispatcher)) as TDKMainThreadDispatcher;
-                        
-                    if(_instance == null )
-                    {
-                        // create a new instance
-                        _instance = new GameObject("TDKMainThreadDispatcher", new Type[] {
-                            typeof(TDKMainThreadDispatcher),
-                        }).GetComponent<TDKMainThreadDispatcher>();
+                    // create a new instance
+                    _instance = new GameObject("TDKMainThreadDispatcher", new Type[] {
+                        typeof(TDKMainThreadDispatcher),
+                    }).GetComponent<TDKMainThreadDispatcher>();
 
-                        DontDestroyOnLoad(_instance.gameObject);
-                    }
+                    DontDestroyOnLoad(_instance.gameObject);
                 }
-
-                return _instance;
             }
         }
 
@@ -49,13 +43,13 @@ namespace Treasure
         /// Locks the queue and adds the IEnumerator to the queue
         /// </summary>
         /// <param name="action">IEnumerator function that will be executed from the main thread.</param>
-        public void Enqueue(IEnumerator action)
+        public static void Enqueue(IEnumerator action)
         {
             // Debug.Log("[TDKMainThreadDispatcher] Enqueuing enumerator");
             lock (_executionQueue)
             {
-                _executionQueue.Enqueue (() => {  
-                    StartCoroutine (action); 
+                _executionQueue.Enqueue(() => {
+                    _instance.StartCoroutine(action);
                 });
             }
         }
@@ -64,12 +58,13 @@ namespace Treasure
         /// Locks the queue and adds the Action to the queue
         /// </summary>
         /// <param name="action">function that will be executed from the main thread.</param>
-        public void Enqueue(Action action)
+        public static void Enqueue(Action action)
         {
             // Debug.Log("[TDKMainThreadDispatcher] Enqueuing action");
             Enqueue(ActionWrapper(action));
         }
-        IEnumerator ActionWrapper(Action a)
+
+        static IEnumerator ActionWrapper(Action a)
         {
             // Debug.Log("[TDKMainThreadDispatcher] Executing action");
             a();

--- a/Assets/Treasure/TDK/Runtime/Infrastructure/TDKTimeKeeper.cs
+++ b/Assets/Treasure/TDK/Runtime/Infrastructure/TDKTimeKeeper.cs
@@ -23,7 +23,7 @@ namespace Treasure
                 yield return new WaitForSeconds(RETRY_INTERVAL);
             }
 
-            var endpoint = TDK.Instance.AppConfig.Environment == TDKConfig.Env.PROD ?
+            var endpoint = TDK.AppConfig.Environment == TDKConfig.Env.PROD ?
                 Constants.SERVER_TIME_ENDPOINT_PROD :
                 Constants.SERVER_TIME_ENDPOINT_DEV;
 

--- a/Assets/Treasure/TDK/Runtime/Services/Helika/TDKHelikaConfig.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Helika/TDKHelikaConfig.cs
@@ -17,7 +17,7 @@ namespace Treasure
         public string ApiKey
         {
             get {
-                if(TDK.Instance.AppConfig.Environment == TDKConfig.Env.PROD) {
+                if(TDK.AppConfig.Environment == TDKConfig.Env.PROD) {
                     #if UNITY_IOS
                     return _prodApiKeyIos;
                     #elif UNITY_ANDROID

--- a/Assets/Treasure/TDK/Runtime/Services/Helika/TDKHelikaService.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Helika/TDKHelikaService.cs
@@ -13,15 +13,15 @@ namespace Treasure
         {
             base.Awake();
 
-            _config = TDK.Instance.AppConfig.GetModuleConfig<TDKHelikaConfig>();
+            _config = TDK.AppConfig.GetModuleConfig<TDKHelikaConfig>();
 
             if (_config != null) {
                 EventManager.Instance.Init(
                     _config.ApiKey,
-                    TDK.Instance.AppConfig.CartridgeTag,
-                    TDK.Instance.AppConfig.Environment == TDKConfig.Env.PROD ? HelikaEnvironment.Production : HelikaEnvironment.Develop,
+                    TDK.AppConfig.CartridgeTag,
+                    TDK.AppConfig.Environment == TDKConfig.Env.PROD ? HelikaEnvironment.Production : HelikaEnvironment.Develop,
                     TelemetryLevel.All,
-                    TDK.Instance.AppConfig.Environment == TDKConfig.Env.DEV
+                    TDK.AppConfig.Environment == TDKConfig.Env.DEV
                 );
             } else {
                 TDKLogger.LogWarning("[TDKHelikaService] Helika config not found, skipping initialization.");
@@ -41,7 +41,7 @@ namespace Treasure
 
             eventProps.Add(AnalyticsConstants.PROP_TDK_VERSION, TDKVersion.version);
             eventProps.Add(AnalyticsConstants.PROP_TDK_FLAVOUR, TDKVersion.name);
-            eventProps.Add(AnalyticsConstants.PROP_APP_ENVIRONMENT, TDK.Instance.AppConfig.Environment);
+            eventProps.Add(AnalyticsConstants.PROP_APP_ENVIRONMENT, TDK.AppConfig.Environment);
 
             // add chain id (using indexer in case it was added upstream)
             eventProps[AnalyticsConstants.PROP_CHAIN_ID] = _chainId;

--- a/Assets/Treasure/TDK/Runtime/Services/Thirdweb/TDKThirdwebService.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Thirdweb/TDKThirdwebService.cs
@@ -22,7 +22,7 @@ namespace Treasure
         {
             base.Awake();
 
-            ChainId defaultChainId = TDK.Instance.AppConfig.DefaultChainId;
+            ChainId defaultChainId = TDK.AppConfig.DefaultChainId;
             
             if (defaultChainId != ChainId.Unknown) {
                 InitializeSDK(Constants.ChainIdToName[defaultChainId]);
@@ -34,7 +34,7 @@ namespace Treasure
         public void InitializeSDK(string chainIdentifier)
         {
             TDKLogger.LogDebug("Initializing Thirdweb SDK for chain: " + chainIdentifier);
-            var tdkConfig = TDK.Instance.AppConfig;
+            var tdkConfig = TDK.AppConfig;
             var supportedChains = ((ChainId[])Enum.GetValues(typeof(ChainId)))
                 .Where(chainId => chainId != ChainId.Unknown)
                 .Select(chainId => new ThirdwebChainData { chainName = Constants.ChainIdToName[chainId] })

--- a/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.Cache.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.Cache.cs
@@ -72,7 +72,7 @@ namespace Treasure
                         break;
                     }
                 }
-                await Task.Delay(TimeSpan.FromSeconds(TDK.Instance.AppConfig.AnalyticsDiscFlushFrequencySeconds));
+                await Task.Delay(TimeSpan.FromSeconds(TDK.AppConfig.AnalyticsDiscFlushFrequencySeconds));
             }
         }
 
@@ -83,18 +83,18 @@ namespace Treasure
             _diskFlushCancellationTokenSource = null;
             _flushCacheTimer?.Dispose();
             _flushCacheTimer = null;
-            await FlushMemoryCache();
+            await FlushMemoryCache(appIsQuitting: true);
         }
 
         private void ResetFlushTimer()
         {
             _flushCacheTimer?.Change(
-                TimeSpan.FromSeconds(TDK.Instance.AppConfig.AnalyticsMemoryFlushFrequencySeconds),
-                TimeSpan.FromSeconds(TDK.Instance.AppConfig.AnalyticsMemoryFlushFrequencySeconds)
+                TimeSpan.FromSeconds(TDK.AppConfig.AnalyticsMemoryFlushFrequencySeconds),
+                TimeSpan.FromSeconds(TDK.AppConfig.AnalyticsMemoryFlushFrequencySeconds)
             );
         }
 
-        private async Task FlushMemoryCache()
+        private async Task FlushMemoryCache(bool appIsQuitting = false)
         {
             List<string> memoryCacheCopy;
             lock (_memoryCache)

--- a/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.IO-WebGL.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.IO-WebGL.cs
@@ -15,10 +15,10 @@ namespace Treasure
                 eventStr = "[" + eventStr + "]";
             }
 
-            string baseUrl = TDK.Instance.AppConfig.AnalyticsApiUrl;
-            if (!TDK.Instance.AppConfig.AnalyticsApiUrl.EndsWith("/"))
+            string baseUrl = TDK.AppConfig.AnalyticsApiUrl;
+            if (!TDK.AppConfig.AnalyticsApiUrl.EndsWith("/"))
             {
-                baseUrl = TDK.Instance.AppConfig.AnalyticsApiUrl + "/";
+                baseUrl = TDK.AppConfig.AnalyticsApiUrl + "/";
             }
 
             using (UnityWebRequest webRequest = UnityWebRequest.PostWwwForm($"{baseUrl}events", eventStr))
@@ -26,7 +26,7 @@ namespace Treasure
                 webRequest.SetRequestHeader("Content-Type", "application/json");
                 
                 // Set the API key header
-                webRequest.SetRequestHeader("x-api-key", TDK.Instance.AppConfig.ApiKey);
+                webRequest.SetRequestHeader("x-api-key", TDK.AppConfig.ApiKey);
 
                 yield return webRequest.SendWebRequest();
 

--- a/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.IO.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.IO.cs
@@ -36,16 +36,16 @@ namespace Treasure
                 TDKLogger.LogDebug("[TDKAnalyticsService.IO:SendEventBatch] Payload:" + payload);
 
                 // Set the base address ensuring trailing slash
-                string baseAddress = TDK.Instance.AppConfig.AnalyticsApiUrl;
-                if (!TDK.Instance.AppConfig.AnalyticsApiUrl.EndsWith("/"))
+                string baseAddress = TDK.AppConfig.AnalyticsApiUrl;
+                if (!TDK.AppConfig.AnalyticsApiUrl.EndsWith("/"))
                 {
-                    baseAddress = TDK.Instance.AppConfig.AnalyticsApiUrl + "/";
+                    baseAddress = TDK.AppConfig.AnalyticsApiUrl + "/";
                 }
                 client.BaseAddress = new Uri(baseAddress);
                 client.DefaultRequestHeaders.Add("Accept", "application/json");
 
                 // Set the API key header
-                client.DefaultRequestHeaders.Add("x-api-key", TDK.Instance.AppConfig.ApiKey);
+                client.DefaultRequestHeaders.Add("x-api-key", TDK.AppConfig.ApiKey);
 
                 // send the payload to the analytics backend via HTTP POST request
                 HttpResponseMessage response = await client.PostAsync(

--- a/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Treasure/Analytics/TDKAnalyticsService.cs
@@ -28,7 +28,6 @@ namespace Treasure
 #if !UNITY_WEBGL
         void OnApplicationQuit()
         {
-            appIsQuitting = true;
             TerminateCacheFlushing();
         }
 #endif
@@ -57,7 +56,7 @@ namespace Treasure
                 { AnalyticsConstants.PROP_APP_IDENTIFIER, Application.identifier },
                 { AnalyticsConstants.PROP_APP_IS_EDITOR, Application.isEditor },
                 { AnalyticsConstants.PROP_APP_VERSION, Application.version },
-                { AnalyticsConstants.PROP_APP_ENVIRONMENT, TDK.Instance.AppConfig.Environment }
+                { AnalyticsConstants.PROP_APP_ENVIRONMENT, TDK.AppConfig.Environment }
             };
         }
 
@@ -71,7 +70,7 @@ namespace Treasure
             {
                 { AnalyticsConstants.PROP_SMART_ACCOUNT, string.IsNullOrEmpty(_smartAccountAddress) ? string.Empty : _smartAccountAddress }, // smart_account
                 { AnalyticsConstants.PROP_CHAIN_ID, _chainId }, // chain_id
-                { AnalyticsConstants.CARTRIDGE_TAG, TDK.Instance.AppConfig.CartridgeTag }, // cartridgeTag
+                { AnalyticsConstants.CARTRIDGE_TAG, TDK.AppConfig.CartridgeTag }, // cartridgeTag
                 { AnalyticsConstants.PROP_NAME, eventName }, // event_name
                 { AnalyticsConstants.PROP_SESSION_ID, _sessionId }, // session_id
                 { AnalyticsConstants.PROP_ID, Guid.NewGuid().ToString("N") }, // event_id


### PR DESCRIPTION
- Avoid recreating instance of TDK on quit
- Explicitly initialize TDKMainThreadDispatcher. Make Enqueue static
- Pass isAppQuitting flag from TerminateCacheFlushing

Implemented the ideas mentioned [here](https://github.com/TreasureProject/tdk-unity/pull/96#issuecomment-2290016783) to prevent TDK and TDKMainThreadDispatcher from being permanently added to the open scene when the game is stopped with pending events