### PR TITLE
remove factory address from config; use address from constants

### DIFF
--- a/Assets/Treasure/TDK/Runtime/Common/Constants.cs
+++ b/Assets/Treasure/TDK/Runtime/Common/Constants.cs
@@ -71,7 +71,7 @@ namespace Treasure
                     { Contract.CorruptionRemoval, "0xdd8b0dd8128873049b1d528262724bde600f5be2" },
                     { Contract.ERC1155TokenSetCorruptionHandler, "0x937817e7fe8e3b3543db46f14473d5f110a79ece" },
                     { Contract.HarvesterEmberwing, "0x816c0717cf263e7da4cd33d4979ad15dbb70f122" },
-                    { Contract.ManagedAccountFactory, "0xae7f7e9286f5f9ede167a19d1d605df4fdbc417b" },
+                    { Contract.ManagedAccountFactory, "0x463effb51873c7720c810ac7fb2e145ec2f8cc60" },
                     { Contract.MagicswapV2Router, "0xa8654a8097b78daf740c1e2ada8a6bf3cd60da50" },
                     { Contract.ZeeverseZee, "0xb1af672c7e0e8880c066ecc24930a12ff2ee8534" },
                     { Contract.ZeeverseItems, "0xfaad5aa3209ab1b25ede22ed4da5521538b649fa" },

--- a/Assets/Treasure/TDK/Runtime/Services/Thirdweb/TDKThirdwebService.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Thirdweb/TDKThirdwebService.cs
@@ -13,7 +13,7 @@ namespace Treasure
         public ThirdwebClient Client { get; private set; }
         public SmartWallet ActiveWallet { get; private set; }
         public bool Initialized { get; private set; }
-        
+
         private string bundleId;
         private CancellationTokenSource _connectionCancelationTokenSource;
 
@@ -22,12 +22,15 @@ namespace Treasure
             base.Awake();
 
             ChainId defaultChainId = TDK.AppConfig.DefaultChainId;
-            
-            if (defaultChainId != ChainId.Unknown) {
+
+            if (defaultChainId != ChainId.Unknown)
+            {
                 InitializeSDK(Constants.ChainIdToName[defaultChainId]);
-            } else {
+            }
+            else
+            {
                 TDKLogger.LogWarning("[TDKThirdwebService] Invalid default chain in config, skipping initialization.");
-            }            
+            }
         }
 
         private void InitializeSDK(string chainIdentifier)
@@ -64,13 +67,14 @@ namespace Treasure
         //     await Task.Delay(1000);
         //     _ = TDK.Connect.Reconnect("farchi@treasure.lol");
         // }
-        
-        public async Task ConnectWallet(EcosystemWalletOptions ecosystemWalletOptions, int chainId, bool isSilentReconnect) {
+
+        public async Task ConnectWallet(EcosystemWalletOptions ecosystemWalletOptions, int chainId, bool isSilentReconnect)
+        {
             // Allow only one attempt to connect at a time, a new one will cancel any previous
             _connectionCancelationTokenSource?.Cancel();
             _connectionCancelationTokenSource = new CancellationTokenSource();
             var cancellationToken = _connectionCancelationTokenSource.Token;
-            
+
             EcosystemWallet ecosystemWallet = null;
             SmartWallet smartWallet = null;
             try
@@ -86,8 +90,10 @@ namespace Treasure
                 );
                 cancellationToken.ThrowIfCancellationRequested();
                 var isConnected = await ecosystemWallet.IsConnected();
-                if (!isConnected) {
-                    if (isSilentReconnect) {
+                if (!isConnected)
+                {
+                    if (isSilentReconnect)
+                    {
                         TDKLogger.LogDebug($"Could not recreate user automatically, skipping silent reconnect");
                         return;
                     }
@@ -116,8 +122,8 @@ namespace Treasure
                 smartWallet = await SmartWallet.Create(
                     personalWallet: ecosystemWallet,
                     chainId: chainId,
-                    gasless: true,
-                    factoryAddress: TDK.AppConfig.FactoryAddress
+                    factoryAddress: Constants.ContractAddresses[(ChainId)chainId][Contract.ManagedAccountFactory],
+                    gasless: true
                 );
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -127,7 +133,8 @@ namespace Treasure
             }
             catch
             {
-                if (cancellationToken.IsCancellationRequested) {
+                if (cancellationToken.IsCancellationRequested)
+                {
                     TDKLogger.LogInfo("[TDKThirdwebService:ConnectWallet] New connection attempt has been made, ignoring previous connection...");
                 }
                 throw;
@@ -145,7 +152,8 @@ namespace Treasure
             {
                 _connectionCancelationTokenSource?.Cancel(); // cancel any in progress connect operations
                 TDKLogger.LogInfo("[TDKThirdwebService:DisconnectWallet] Clearing active wallet");
-                if (await ActiveWallet.IsConnected()) {
+                if (await ActiveWallet.IsConnected())
+                {
                     var personalWallet = await ActiveWallet.GetPersonalWallet();
                     await personalWallet.Disconnect();
                     await ActiveWallet.Disconnect();
@@ -158,7 +166,8 @@ namespace Treasure
 
         public async Task SwitchNetwork(int chainId)
         {
-            if (ActiveWallet != null && await ActiveWallet.IsConnected()) {
+            if (ActiveWallet != null && await ActiveWallet.IsConnected())
+            {
                 await ActiveWallet.SwitchNetwork(chainId);
             }
         }

--- a/Assets/Treasure/TDK/Runtime/TDKConfig.cs
+++ b/Assets/Treasure/TDK/Runtime/TDKConfig.cs
@@ -41,7 +41,6 @@ namespace Treasure
         [Serializable]
         public class ConnectConfig
         {
-            public string _factoryAddress;
             public ChainId _devDefaultChainId;
             public ChainId _prodDefaultChainId;
             public int _sessionDurationSec;
@@ -90,8 +89,6 @@ namespace Treasure
         public string ClientId => Environment == Env.DEV ? _general._devClientId : _general._prodClientId;
         public string EcosystemId => string.IsNullOrEmpty(_general._ecosystemId) ? "ecosystem.treasure" : _general._ecosystemId;
         public string EcosystemPartnerId => _general._ecosystemPartnerId;
-
-        public string FactoryAddress => string.IsNullOrEmpty(_connect._factoryAddress) ? null : _connect._factoryAddress;
 
         public ChainId DefaultChainId =>
             Environment == Env.DEV ? _connect._devDefaultChainId : _connect._prodDefaultChainId;
@@ -179,7 +176,6 @@ namespace Treasure
             // Connect
             _connect = new ConnectConfig
             {
-                _factoryAddress = config.connect.factoryAddress,
                 _devDefaultChainId = Constants.NameToChainId.GetValueOrDefault(
                     config.connect.devDefaultChainIdentifier ?? "",
                     ChainId.Unknown
@@ -246,7 +242,6 @@ namespace Treasure
                 public double nativeTokenLimitPerTransaction;
             }
 
-            public string factoryAddress;
             public string devDefaultChainIdentifier;
             public string prodDefaultChainIdentifier;
             public int sessionDurationSec;


### PR DESCRIPTION
- Removes the `factoryAddress` config in favor of the provided Treasure ManagedAccountFactory contract address in the `Constants` file
- Updates the Arbitrum Sepolia ManagedAccountFactory address to match other chains