### PR TITLE
add options to WaitForTransaction

### DIFF
--- a/Assets/Treasure/TDK/Runtime/Common/TDK.Common.cs
+++ b/Assets/Treasure/TDK/Runtime/Common/TDK.Common.cs
@@ -24,7 +24,7 @@ namespace Treasure
             return Constants.ContractAddresses[chainId][contract];
         }
 
-        public async Task<Transaction> WaitForTransaction(string queueId)
+        public async Task<Transaction> WaitForTransaction(string queueId, int maxRetries = 15, int retryMs = 2500, int initialWaitMs = 4000)
         {
             var retries = 0;
             Transaction transaction;
@@ -32,10 +32,10 @@ namespace Treasure
             {
                 if (retries > 0)
                 {
-                    // equivalent to `await Task.Delay(2500);` but works on webgl
+                    // equivalent to `await Task.Delay();` but works on webgl
                     var sw = new System.Diagnostics.Stopwatch();
                     sw.Start();
-                    while (sw.ElapsedMilliseconds < 2500)
+                    while (sw.ElapsedMilliseconds < (retries == 0 ? initialWaitMs : retryMs))
                     {
                         await Task.Yield();
                     }
@@ -45,7 +45,7 @@ namespace Treasure
                 transaction = await TDK.API.GetTransactionByQueueId(queueId);
                 retries++;
             } while (
-                retries < 15 &&
+                retries < maxRetries &&
                 transaction.status != "errored" &&
                 transaction.status != "cancelled" &&
                 transaction.status != "mined"

--- a/Assets/Treasure/TDK/Runtime/Common/TDK.Common.cs
+++ b/Assets/Treasure/TDK/Runtime/Common/TDK.Common.cs
@@ -30,17 +30,14 @@ namespace Treasure
             Transaction transaction;
             do
             {
-                if (retries > 0)
+                // equivalent to `await Task.Delay();` but works on webgl
+                var sw = new System.Diagnostics.Stopwatch();
+                sw.Start();
+                while (sw.ElapsedMilliseconds < (retries == 0 ? initialWaitMs : retryMs))
                 {
-                    // equivalent to `await Task.Delay();` but works on webgl
-                    var sw = new System.Diagnostics.Stopwatch();
-                    sw.Start();
-                    while (sw.ElapsedMilliseconds < (retries == 0 ? initialWaitMs : retryMs))
-                    {
-                        await Task.Yield();
-                    }
-                    sw.Stop();
+                    await Task.Yield();
                 }
+                sw.Stop();
 
                 transaction = await TDK.API.GetTransactionByQueueId(queueId);
                 retries++;


### PR DESCRIPTION
- Matches the "wait for transaction" logic with the TDK JS by separating the initial wait time from the retry time. Transactions are rarely complete in less than 4s, so this change minimizes the amount of status calls the client will make
- Adds new parameters to the function so consumers can tweak it as needed