### PR TITLE
clean up exposed interfaces; add helpers for common contract reads

### DIFF
--- a/Assets/Treasure/Example/Scripts/IdentityUI.cs
+++ b/Assets/Treasure/Example/Scripts/IdentityUI.cs
@@ -35,8 +35,7 @@ public class IdentityUI : MonoBehaviour
     {
         try
         {
-            var chainId = TDK.Connect.GetChainId();
-            await TDK.Identity.ValidateUserSession(chainId, value);
+            await TDK.Identity.ValidateUserSession(TDK.Connect.ChainId, value);
         }
         catch (Exception e)
         {
@@ -48,7 +47,7 @@ public class IdentityUI : MonoBehaviour
     {
         var contractAddress = TDK.Common.GetContractAddress(Contract.Magic);
         var thirdwebService = TDKServiceLocator.GetService<TDKThirdwebService>();
-        var contract = await ThirdwebContract.Create(thirdwebService.Client, contractAddress, TDK.Connect.GetChainIdAsInt());
+        var contract = await ThirdwebContract.Create(thirdwebService.Client, contractAddress, TDK.Connect.ChainIdNumber);
         var balance = await contract.ERC20_BalanceOf(TDK.Identity.Address);
         TDKLogger.LogInfo($"Magic balance: {Utils.ToEth(balance.ToString())}");
     }
@@ -56,7 +55,8 @@ public class IdentityUI : MonoBehaviour
     public async void OnMintMagicBtn()
     {
         TDKLogger.LogInfo("Minting 1,000 MAGIC...");
-        var transaction = await TDK.API.WriteTransaction(Contract.Magic, "mint", new object[] { TDK.Identity.Address, Utils.ToWei("1000") });
+        var contractAddress = TDK.Common.GetContractAddress(Contract.Magic);
+        var transaction = await TDK.API.WriteTransaction(contractAddress, "mint", new object[] { TDK.Identity.Address, Utils.ToWei("1000") });
         transaction = await TDK.Common.WaitForTransaction(transaction.queueId);
         if (transaction.status == "errored")
         {
@@ -73,7 +73,7 @@ public class IdentityUI : MonoBehaviour
         TDKLogger.LogInfo("Minting 1,000 MAGIC...");
         var contractAddress = TDK.Common.GetContractAddress(Contract.Magic);
         var thirdwebService = TDKServiceLocator.GetService<TDKThirdwebService>();
-        var contract = await ThirdwebContract.Create(thirdwebService.Client, contractAddress, TDK.Connect.GetChainIdAsInt());
+        var contract = await ThirdwebContract.Create(thirdwebService.Client, contractAddress, TDK.Connect.ChainIdNumber);
         var tx = await ThirdwebContract.Prepare(
             wallet: thirdwebService.ActiveWallet,
             contract: contract,

--- a/Assets/Treasure/TDK/Runtime/API/TDK.API.cs
+++ b/Assets/Treasure/TDK/Runtime/API/TDK.API.cs
@@ -46,8 +46,7 @@ namespace Treasure
             }
             else
             {
-                var chainId = TDK.Connect.GetChainIdAsInt();
-                req.SetRequestHeader("X-Chain-Id", chainId.ToString());
+                req.SetRequestHeader("X-Chain-Id", TDK.Connect.ChainIdNumber.ToString());
             }
 
             // Set auth token with override option
@@ -95,8 +94,7 @@ namespace Treasure
             }
             else
             {
-                var chainId = TDK.Connect.GetChainIdAsInt();
-                req.SetRequestHeader("X-Chain-Id", chainId.ToString());
+                req.SetRequestHeader("X-Chain-Id", TDK.Connect.ChainIdNumber.ToString());
             }
 
             // Set auth token with override option

--- a/Assets/Treasure/TDK/Runtime/API/Transaction.cs
+++ b/Assets/Treasure/TDK/Runtime/API/Transaction.cs
@@ -74,16 +74,6 @@ namespace Treasure
             });
         }
 
-        public async Task<Transaction> WriteTransaction(Contract contract, string functionName, object[] args)
-        {
-            var contractAddress = TDK.Common.GetContractAddress(contract);
-            return await WriteTransaction(
-                address: contractAddress,
-                functionName: functionName,
-                args: args
-            );
-        }
-
         public async Task<Transaction> SendRawTransaction(SendRawTransactionBody body)
         {
             body.backendWallet ??= TDK.AppConfig.GetBackendWallet();

--- a/Assets/Treasure/TDK/Runtime/Common/Constants.cs
+++ b/Assets/Treasure/TDK/Runtime/Common/Constants.cs
@@ -14,16 +14,9 @@ namespace Treasure
 
     public enum Contract
     {
-        // Tokens
         Magic,
-        Vee,
-        // Treasure Misc
         ManagedAccountFactory,
         MagicswapV2Router,
-        // Zeeverse
-        ZeeverseZee,
-        ZeeverseItems,
-        ZeeverseVeeClaimer,
     }
 
     public static class Constants
@@ -40,27 +33,21 @@ namespace Treasure
             {
                 ChainId.Arbitrum, new Dictionary<Contract, string> {
                     { Contract.Magic, "0x539bde0d7dbd336b79148aa742883198bbf60342" },
-                    { Contract.Vee, "0x0caadd427a6feb5b5fc1137eb05aa7ddd9c08ce9" },
                     { Contract.ManagedAccountFactory, "0x463effb51873c7720c810ac7fb2e145ec2f8cc60" },
                     { Contract.MagicswapV2Router, "0xf7c8f888720d5af7c54dfc04afe876673d7f5f43" },
-                    { Contract.ZeeverseZee, "0x094fa8ae08426ab180e71e60fa253b079e13b9fe" },
-                    { Contract.ZeeverseItems, "0x58318bceaa0d249b62fad57d134da7475e551b47" },
-                    { Contract.ZeeverseVeeClaimer, "0x1cebdde81a9e4cd377bc7da5000797407cf9a58a" },
                 }
             },
             {
                 ChainId.ArbitrumSepolia, new Dictionary<Contract, string> {
                     { Contract.Magic, "0x55d0cf68a1afe0932aff6f36c87efa703508191c" },
-                    { Contract.Vee, "0x23be0504127475387a459fe4b01e54f1e336ffae" },
                     { Contract.ManagedAccountFactory, "0x463effb51873c7720c810ac7fb2e145ec2f8cc60" },
                     { Contract.MagicswapV2Router, "0xa8654a8097b78daf740c1e2ada8a6bf3cd60da50" },
-                    { Contract.ZeeverseZee, "0xb1af672c7e0e8880c066ecc24930a12ff2ee8534" },
-                    { Contract.ZeeverseItems, "0xfaad5aa3209ab1b25ede22ed4da5521538b649fa" },
-                    { Contract.ZeeverseVeeClaimer, "0xf7abce65b1e683b7a42113f69ef76ee35cabbddc" }
                 }
             },
             {
-                ChainId.Mainnet, new Dictionary<Contract, string> {}
+                ChainId.Mainnet, new Dictionary<Contract, string> {
+                    { Contract.ManagedAccountFactory, "0x463effb51873c7720c810ac7fb2e145ec2f8cc60" },
+                }
             },
             {
                 ChainId.Sepolia, new Dictionary<Contract, string> {

--- a/Assets/Treasure/TDK/Runtime/Common/TDK.Common.cs
+++ b/Assets/Treasure/TDK/Runtime/Common/TDK.Common.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using System.Threading.Tasks;
+using Thirdweb;
 using UnityEngine;
 
 namespace Treasure
@@ -18,10 +19,9 @@ namespace Treasure
     {
         public Common() { }
 
-        public string GetContractAddress(Contract contract)
+        public string GetContractAddress(Contract contract, ChainId chainId = ChainId.Unknown)
         {
-            var chainId = TDK.Connect.GetChainId();
-            return Constants.ContractAddresses[chainId][contract];
+            return Constants.ContractAddresses[chainId == ChainId.Unknown ? TDK.Connect.ChainId : chainId][contract];
         }
 
         public async Task<Transaction> WaitForTransaction(string queueId, int maxRetries = 15, int retryMs = 2500, int initialWaitMs = 4000)
@@ -66,14 +66,10 @@ namespace Treasure
             return transaction;
         }
 
-        public async Task<Transaction> ApproveERC20(Contract contract, string operatorAddress, BigInteger amount)
+        public async Task<ThirdwebContract> GetContract(string address)
         {
-            var transaction = await TDK.API.WriteTransaction(
-                contract: contract,
-                functionName: "approve",
-                args: new string[] { operatorAddress, amount.ToString() }
-            );
-            return await WaitForTransaction(transaction.queueId);
+            var client = TDKServiceLocator.GetService<TDKThirdwebService>().Client;
+            return await ThirdwebContract.Create(client, address, TDK.Connect.ChainIdNumber);
         }
 
         public async Task<Transaction> ApproveERC20(string address, string operatorAddress, BigInteger amount)
@@ -82,16 +78,6 @@ namespace Treasure
                 address: address,
                 functionName: "approve",
                 args: new string[] { operatorAddress, amount.ToString() }
-            );
-            return await WaitForTransaction(transaction.queueId);
-        }
-
-        public async Task<Transaction> ApproveERC1155(Contract contract, string operatorAddress)
-        {
-            var transaction = await TDK.API.WriteTransaction(
-                contract: contract,
-                functionName: "setApprovalForAll",
-                args: new string[] { operatorAddress, "true" }
             );
             return await WaitForTransaction(transaction.queueId);
         }
@@ -106,16 +92,6 @@ namespace Treasure
             return await WaitForTransaction(transaction.queueId);
         }
 
-        public async Task<Transaction> ApproveERC721(Contract contract, string operatorAddress)
-        {
-            var transaction = await TDK.API.WriteTransaction(
-                contract: contract,
-                functionName: "setApprovalForAll",
-                args: new string[] { operatorAddress, "true" }
-            );
-            return await WaitForTransaction(transaction.queueId);
-        }
-
         public async Task<Transaction> ApproveERC721(string address, string operatorAddress)
         {
             var transaction = await TDK.API.WriteTransaction(
@@ -124,6 +100,27 @@ namespace Treasure
                 args: new string[] { operatorAddress, "true" }
             );
             return await WaitForTransaction(transaction.queueId);
+        }
+
+        public async Task<BigInteger> GetERC20Balance(string tokenAddress, string address)
+        {
+            var contract = await GetContract(tokenAddress);
+            return await contract.ERC20_BalanceOf(address);
+        }
+
+        public async Task<string> GetFormattedERC20Balance(string tokenAddress, string address)
+        {
+            var contract = await GetContract(tokenAddress);
+            var decimalsTask = contract.ERC20_Decimals();
+            var balanceTask = contract.ERC20_BalanceOf(address);
+            await Task.WhenAll(decimalsTask, balanceTask);
+            return Utils.FormatERC20(balanceTask.Result.ToString(), 4, decimalsTask.Result);
+        }
+
+        public async Task<string> GetFormattedERC20Balance(string tokenAddress, string address, int decimals)
+        {
+            var balance = await GetERC20Balance(tokenAddress, address);
+            return Utils.FormatERC20(balance.ToString(), 4, decimals);
         }
     }
 }

--- a/Assets/Treasure/TDK/Runtime/Connect/TDK.Connect.cs
+++ b/Assets/Treasure/TDK/Runtime/Connect/TDK.Connect.cs
@@ -47,14 +47,14 @@ namespace Treasure
         #endregion
 
         #region accessors / mutators
-        public ChainId GetChainId()
+        public ChainId ChainId
         {
-            return _chainId;
+            get { return _chainId; }
         }
 
-        public int GetChainIdAsInt()
+        public int ChainIdNumber
         {
-            return (int)_chainId;
+            get { return (int)_chainId; }
         }
 
         public string Address
@@ -75,26 +75,27 @@ namespace Treasure
         #endregion
 
         #region private methods
-        private async Task ConnectWallet(EcosystemWalletOptions ecosystemWalletOptions, bool isSilentReconnect = false) {
-            if (TDK.Identity.IsUsingTreasureLauncher) {
+        private async Task ConnectWallet(EcosystemWalletOptions ecosystemWalletOptions, bool isSilentReconnect = false)
+        {
+            if (TDK.Identity.IsUsingTreasureLauncher)
+            {
                 TDKLogger.Log("[TDK.Connect:ConnectWallet] Using launcher token, skipping");
                 return;
             }
-            if (!isSilentReconnect) {
+            if (!isSilentReconnect)
+            {
                 var authMethod = ecosystemWalletOptions.AuthProvider.ToString();
                 if (authMethod == AuthProvider.Default.ToString()) authMethod = "Email/Phone";
                 TDKLogger.Log($"[TDK.Connect:ConnectWallet] Connecting via {authMethod}...");
             }
-            
-            var chainId = GetChainIdAsInt();
 
             var thirdwebService = TDKServiceLocator.GetService<TDKThirdwebService>();
-            await thirdwebService.ConnectWallet(ecosystemWalletOptions, chainId, isSilentReconnect);
-            
+            await thirdwebService.ConnectWallet(ecosystemWalletOptions, ChainIdNumber, isSilentReconnect);
+
             _address = await thirdwebService.ActiveWallet.GetAddress();
             OnConnected?.Invoke(_address);
-            
-            TDK.Analytics.SetTreasureConnectInfo(_address, chainId);
+
+            TDK.Analytics.SetTreasureConnectInfo(_address, ChainIdNumber);
             TDKLogger.LogDebug($"[TDK.Connect:ConnectWallet] Connection success!");
         }
 
@@ -112,25 +113,26 @@ namespace Treasure
 
         public async Task SetChainId(ChainId chainId, bool startUserSession = false)
         {
-            if (TDK.Identity.IsUsingTreasureLauncher) {
+            if (TDK.Identity.IsUsingTreasureLauncher)
+            {
                 TDKLogger.Log("[TDK.Connect:SetChainId] Using launcher token, skipping");
                 return;
             }
 
-            if (GetChainId() == chainId)
+            if (chainId == ChainId)
             {
                 TDKLogger.Log($"Chain is already set to {chainId}");
                 return;
             }
 
             _chainId = chainId;
-            
+
             var thirdwebService = TDKServiceLocator.GetService<TDKThirdwebService>();
-            await thirdwebService.SwitchNetwork(GetChainIdAsInt());
+            await thirdwebService.SwitchNetwork(ChainIdNumber);
 
             TDKLogger.Log($"Switched chain to {chainId}");
 
-            TDK.Analytics.SetTreasureConnectInfo(_address, GetChainIdAsInt());
+            TDK.Analytics.SetTreasureConnectInfo(_address, ChainIdNumber);
 
             if (startUserSession)
             {
@@ -167,7 +169,8 @@ namespace Treasure
             await ConnectWallet(ecosystemWalletOptions);
         }
 
-        public async Task Reconnect(string email) {
+        public async Task Reconnect(string email)
+        {
             TDKLogger.LogDebug($"[TDK.Connect:Reconnect] Reconnecting email ({email})...");
             var ecosystemWalletOptions = new EcosystemWalletOptions(email: email);
             await Reconnect(ecosystemWalletOptions);
@@ -175,7 +178,8 @@ namespace Treasure
 
         public async Task Disconnect()
         {
-            if (TDK.Identity.IsUsingTreasureLauncher) {
+            if (TDK.Identity.IsUsingTreasureLauncher)
+            {
                 TDKLogger.Log("[TDK.Connect:Disconnect] Using launcher token, skipping.");
                 return;
             }

--- a/Assets/Treasure/TDK/Runtime/Identity/TDK.Identity.cs
+++ b/Assets/Treasure/TDK/Runtime/Identity/TDK.Identity.cs
@@ -143,8 +143,10 @@ namespace Treasure
                 ));
         }
 
-        private async Task StartLauncherSessionRequest() {
-            var body = JsonConvert.SerializeObject(new {
+        private async Task StartLauncherSessionRequest()
+        {
+            var body = JsonConvert.SerializeObject(new
+            {
                 backendWallet = TDK.AppConfig.GetBackendWallet(),
                 approvedTargets = TDK.AppConfig.GetCallTargets(),
                 nativeTokenLimitPerTransaction = TDK.AppConfig.GetNativeTokenLimitPerTransaction(),
@@ -218,13 +220,13 @@ namespace Treasure
 
         public async Task<string> StartUserSession(ChainId sessionChainId = ChainId.Unknown, string sessionAuthToken = null)
         {
-            if (IsUsingTreasureLauncher) {
+            if (IsUsingTreasureLauncher)
+            {
                 TDKLogger.LogError("Unable to start user session. Use StartUserSessionViaLauncher instead.");
                 return await Task.FromResult(string.Empty);
             }
             // Check if user already has a valid session for the specified chain
-            var currentChainId = TDK.Connect.GetChainId();
-            var chainId = sessionChainId == ChainId.Unknown ? currentChainId : sessionChainId;
+            var chainId = sessionChainId == ChainId.Unknown ? TDK.Connect.ChainId : sessionChainId;
             var authToken = !string.IsNullOrEmpty(sessionAuthToken) ? sessionAuthToken : _authToken;
             if (!string.IsNullOrEmpty(authToken))
             {
@@ -244,7 +246,7 @@ namespace Treasure
             }
 
             // Switch chains if not on the correct one already
-            if (chainId != currentChainId)
+            if (chainId != TDK.Connect.ChainId)
             {
                 TDKLogger.Log($"Switching chain to {chainId}");
                 await TDK.Connect.SetChainId(chainId);
@@ -322,7 +324,8 @@ namespace Treasure
 
         public async Task EndUserSession()
         {
-            if (IsUsingTreasureLauncher) {
+            if (IsUsingTreasureLauncher)
+            {
                 TDKLogger.Log("[TDK.Identity:EndUserSession] Using launcher token, skipping.");
                 return;
             }
@@ -340,19 +343,23 @@ namespace Treasure
             _authToken = null;
         }
 
-        public async Task StartUserSessionViaLauncher() {
-            if (!IsUsingTreasureLauncher) {
+        public async Task StartUserSessionViaLauncher()
+        {
+            if (!IsUsingTreasureLauncher)
+            {
                 TDKLogger.LogError("Unable to start user session. Use StartUserSession instead.");
                 return;
             }
             TDKLogger.Log("Starting session via launcher token");
             await StartLauncherSessionRequest();
-            
-            var user = await ValidateUserSession(TDK.Connect.GetChainId(), TreasureLauncherUtils.GetLauncherAuthToken());
+
+            var user = await ValidateUserSession(TDK.Connect.ChainId, TreasureLauncherUtils.GetLauncherAuthToken());
             if (user.HasValue)
             {
                 TDKLogger.Log("User session validated successfully");
-            } else {
+            }
+            else
+            {
                 TDKLogger.Log("Unable to validate user session");
             }
         }
@@ -362,19 +369,21 @@ namespace Treasure
             try
             {
                 var authToken = TreasureLauncherUtils.GetLauncherAuthToken();
-                if (authToken == null) {
+                if (authToken == null)
+                {
                     return;
                 }
 
                 _address = TreasureLauncherUtils.GetWalletAddressFromJwt();
                 TDKLogger.LogDebug("Successfully connected from launcher!");
                 TDK.Connect.OnConnected?.Invoke(_address);
-                TDK.Analytics.SetTreasureConnectInfo(_address, TDK.Connect.GetChainIdAsInt()); 
+                TDK.Analytics.SetTreasureConnectInfo(_address, TDK.Connect.ChainIdNumber);
 
                 TDKLogger.LogDebug("Checking for launcher token session...");
-                await TDK.Identity.ValidateUserSession(TDK.Connect.GetChainId(), authToken);
+                await TDK.Identity.ValidateUserSession(TDK.Connect.ChainId, authToken);
 
-                if (!IsAuthenticated) {
+                if (!IsAuthenticated)
+                {
                     TDKLogger.LogDebug("No session found. Call StartUserSessionViaLauncher to start one");
                 }
             }

--- a/Assets/Treasure/TDK/Runtime/Magicswap/TDK.Magicswap.cs
+++ b/Assets/Treasure/TDK/Runtime/Magicswap/TDK.Magicswap.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Numerics;
 using System.Threading.Tasks;
+using Thirdweb;
 using UnityEngine;
 
 namespace Treasure
@@ -18,12 +19,12 @@ namespace Treasure
     public partial class Magicswap
     {
         public Magicswap() { }
-        
+
         public async Task<List<MagicswapPool>> GetAllPools()
         {
             return await TDK.API.GetAllPools();
         }
-        
+
         public async Task<MagicswapPool> GetPoolById(string id)
         {
             return await TDK.API.GetPoolById(id);
@@ -34,24 +35,56 @@ namespace Treasure
             return await TDK.API.GetRoute(tokenInId, tokenOutId, amount, isExactOut);
         }
 
-        public async Task<Transaction> Swap(SwapBody swapBody) {
+        public async Task<Transaction> Swap(SwapBody swapBody)
+        {
             return await TDK.API.Swap(swapBody);
         }
 
-        public async Task<Transaction> AddLiquidity(string poolId, AddLiquidityBody addLiquidityBody) {
+        public async Task<Transaction> AddLiquidity(string poolId, AddLiquidityBody addLiquidityBody)
+        {
             return await TDK.API.AddLiquidity(poolId, addLiquidityBody);
         }
 
-        public async Task<Transaction> RemoveLiquidity(string poolId, RemoveLiquidityBody removeLiquidityBody) {
+        public async Task<Transaction> RemoveLiquidity(string poolId, RemoveLiquidityBody removeLiquidityBody)
+        {
             return await TDK.API.RemoveLiquidity(poolId, removeLiquidityBody);
         }
 
-        public BigInteger GetQuote(BigInteger amountA, BigInteger reserveA, BigInteger reserveB) {
+        public BigInteger GetQuote(BigInteger amountA, BigInteger reserveA, BigInteger reserveB)
+        {
             return reserveA > 0 ? amountA * reserveB / reserveA : 0;
         }
 
-        public BigInteger GetAmountMin(BigInteger amount, double slippage) {
+        public BigInteger GetAmountMin(BigInteger amount, double slippage)
+        {
             return amount - amount * new BigInteger(System.Math.Ceiling(slippage * 1000)) / 1000;
+        }
+
+        public async Task<BigInteger> GetERC20Allowance(string tokenAddress, string address)
+        {
+            var operatorAddress = TDK.Common.GetContractAddress(Contract.MagicswapV2Router);
+            var contract = await TDK.Common.GetContract(tokenAddress);
+            return await contract.ERC20_Allowance(address, operatorAddress);
+        }
+
+        public async Task<bool> IsERC20Approved(string tokenAddress, string address, BigInteger amount)
+        {
+            var allowance = await GetERC20Allowance(tokenAddress, address);
+            return allowance >= amount;
+        }
+
+        public async Task<bool> IsERC1155Approved(string tokenAddress, string address)
+        {
+            var operatorAddress = TDK.Common.GetContractAddress(Contract.MagicswapV2Router);
+            var contract = await TDK.Common.GetContract(tokenAddress);
+            return await contract.ERC1155_IsApprovedForAll(address, operatorAddress);
+        }
+
+        public async Task<bool> IsERC721Approved(string tokenAddress, string address)
+        {
+            var operatorAddress = TDK.Common.GetContractAddress(Contract.MagicswapV2Router);
+            var contract = await TDK.Common.GetContract(tokenAddress);
+            return await contract.ERC721_IsApprovedForAll(address, operatorAddress);
         }
     }
 }

--- a/Assets/Treasure/TDK/Runtime/Services/Thirdweb/TDKThirdwebService.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Thirdweb/TDKThirdwebService.cs
@@ -59,14 +59,7 @@ namespace Treasure
             TDKLogger.LogInfo("TDKThirdwebService initialized.");
 
             Initialized = true;
-
-            // ReconnectTest();
         }
-
-        // public async void ReconnectTest() {
-        //     await Task.Delay(1000);
-        //     _ = TDK.Connect.Reconnect("farchi@treasure.lol");
-        // }
 
         public async Task ConnectWallet(EcosystemWalletOptions ecosystemWalletOptions, int chainId, bool isSilentReconnect)
         {
@@ -122,7 +115,7 @@ namespace Treasure
                 smartWallet = await SmartWallet.Create(
                     personalWallet: ecosystemWallet,
                     chainId: chainId,
-                    factoryAddress: Constants.ContractAddresses[(ChainId)chainId][Contract.ManagedAccountFactory],
+                    factoryAddress: TDK.Common.GetContractAddress(Contract.ManagedAccountFactory, (ChainId)chainId),
                     gasless: true
                 );
                 cancellationToken.ThrowIfCancellationRequested();

--- a/Assets/Treasure/TDK/Runtime/TDKConfig.cs
+++ b/Assets/Treasure/TDK/Runtime/TDKConfig.cs
@@ -112,22 +112,19 @@ namespace Treasure
 
         public string GetBackendWallet()
         {
-            var chainId = TDK.Connect.GetChainId();
-            var option = _connect._sessionOptions.Find(d => d.chainId == chainId);
+            var option = _connect._sessionOptions.Find(d => d.chainId == TDK.Connect.ChainId);
             return option?.backendWallet.ToLowerInvariant();
         }
 
         public List<string> GetCallTargets()
         {
-            var chainId = TDK.Connect.GetChainId();
-            var option = _connect._sessionOptions.Find(d => d.chainId == chainId);
+            var option = _connect._sessionOptions.Find(d => d.chainId == TDK.Connect.ChainId);
             return option != null ? option.callTargets.ConvertAll(ct => ct.ToLowerInvariant()) : new List<string>();
         }
 
         public BigInteger GetNativeTokenLimitPerTransaction()
         {
-            var chainId = TDK.Connect.GetChainId();
-            var option = _connect._sessionOptions.Find(d => d.chainId == chainId);
+            var option = _connect._sessionOptions.Find(d => d.chainId == TDK.Connect.ChainId);
             var value = option?.nativeTokenLimitPerTransaction ?? 0;
             return BigInteger.Parse(Utils.ToWei(value.ToString()));
         }


### PR DESCRIPTION
- Cleans up some exposed interfaces, particularly around fetching the chain ID
- Adds helpers for common contract reads in `Common` and `Magicswap` namespaces