### PR TITLE
Prevent accidentally closing OTP modal by clicking outside [ENG-655]

### DIFF
--- a/Assets/Treasure/TDK/ConnectInternal/Prefabs/Modals/Landscape/ConfirmLoginModal Landscape.prefab
+++ b/Assets/Treasure/TDK/ConnectInternal/Prefabs/Modals/Landscape/ConfirmLoginModal Landscape.prefab
@@ -1478,7 +1478,8 @@ RectTransform:
   - {fileID: 1601245609589278116}
   - {fileID: 7453570501883411992}
   - {fileID: 5645583662726566013}
-  - {fileID: 1987905680089800220}
+  - {fileID: 8250557196472018136}
+  - {fileID: 4114598748571305697}
   - {fileID: 3763675664412262854}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1544,7 +1545,7 @@ MonoBehaviour:
   infoText: {fileID: 671656708675693775}
   confirmationInputCodeHolder: {fileID: 9026736454687146240}
   confirmCode: {fileID: 9202515568987148471}
-  didntReceiveEmailButton: {fileID: 100349873776821649}
+  goBackButton: {fileID: 7459046754092653327}
   codeInput: {fileID: 1171308267116603761}
   errorText: {fileID: 306560564830245462}
   keyBoardSpace: {fileID: 4957060885636631692}
@@ -1746,6 +1747,155 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!1 &8361814115401065209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8250557196472018136}
+  - component: {fileID: 2552066076115183661}
+  - component: {fileID: 3037833289765116913}
+  - component: {fileID: 6792970101895519092}
+  m_Layer: 5
+  m_Name: LabelText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8250557196472018136
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8361814115401065209}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3592920012158661337}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2552066076115183661
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8361814115401065209}
+  m_CullTransparentMesh: 1
+--- !u!114 &3037833289765116913
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8361814115401065209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "Haven\u2019t received an email?"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: c4ea218dd51bc52448c157e5d9e720e1, type: 2}
+  m_sharedMaterial: {fileID: -6057154001904965228, guid: c4ea218dd51bc52448c157e5d9e720e1, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4286411888
+  m_fontColor: {r: 0.4392157, g: 0.45490196, b: 0.49019608, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &6792970101895519092
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8361814115401065209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48a99fe6f98fe774dafa3ddf0d490f6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 3037833289765116913}
+  type: 3
 --- !u!1 &9026736454687146240
 GameObject:
   m_ObjectHideFlags: 0
@@ -2858,7 +3008,7 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7949950743394551908, guid: b72515ad7f50db24ea387062536bc541, type: 3}
   m_PrefabInstance: {fileID: 5482886320779121978}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &6138091685345964078
+--- !u!1001 &5622923996206582146
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -2866,198 +3016,217 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 3592920012158661337}
     m_Modifications:
-    - target: {fileID: 780174145562233051, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_IsActive
-      value: 0
+    - target: {fileID: 2131894008028889035, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_FlexibleWidth
+      value: -1
       objectReference: {fileID: 0}
-    - target: {fileID: 1656942219936097943, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_text
-      value: "Haven\u2019t received an email?"
+    - target: {fileID: 2131894008028889035, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 44
       objectReference: {fileID: 0}
-    - target: {fileID: 1656942219936097943, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_fontColor.b
-      value: 0.49019608
+    - target: {fileID: 2131894008028889035, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_PreferredHeight
+      value: 44
       objectReference: {fileID: 0}
-    - target: {fileID: 1656942219936097943, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_fontColor.g
-      value: 0.45490196
-      objectReference: {fileID: 0}
-    - target: {fileID: 1656942219936097943, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_fontColor.r
-      value: 0.4392157
-      objectReference: {fileID: 0}
-    - target: {fileID: 1656942219936097943, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4286411888
-      objectReference: {fileID: 0}
-    - target: {fileID: 3586646965343017848, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 2862594196186656857, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3586646965343017848, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 2862594196186656857, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3586646965343017848, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 2862594196186656857, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3586646965343017848, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 2862594196186656857, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3586646965343017848, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 2862594196186656857, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3586646965343017848, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 2862594196186656857, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 3824770152328208627, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 3ec3c9de874d61740baef964614f2710, type: 3}
+    - target: {fileID: 3824770152328208627, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_Color.b
+      value: 0.6392157
+      objectReference: {fileID: 0}
+    - target: {fileID: 3824770152328208627, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_Color.g
+      value: 0.54509807
+      objectReference: {fileID: 0}
+    - target: {fileID: 3824770152328208627, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_Color.r
+      value: 0.44705883
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_text
+      value: Go Back
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontSize
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontStyle
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontColor.b
+      value: 0.6392157
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontColor.g
+      value: 0.54509807
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontColor.r
+      value: 0.44705883
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4288908146
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828821369071648406, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828821369071648406, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828821369071648406, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828821369071648406, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828821369071648406, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828821369071648406, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8225361491217918181, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_Name
+      value: Button(Back)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554024243294804342, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_ChildAlignment
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6073775282054641087, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_TargetGraphic
-      value: 
-      objectReference: {fileID: 4886482520565110457}
-    - target: {fileID: 6255446114179569223, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_PreferredHeight
-      value: 24
-      objectReference: {fileID: 0}
-    - target: {fileID: 6843762273644054300, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_Name
-      value: TextButton(DidntReceiveEmail)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7430015229592980691, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_Color.a
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7430015229592980691, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_Color.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7430015229592980691, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_Color.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7430015229592980691, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9207731092786971527, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9207731092786971527, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9207731092786971527, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 9207731092786971527, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 9207731092786971527, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 158.02002
-      objectReference: {fileID: 0}
-    - target: {fileID: 9207731092786971527, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -22
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 4222676951430765326, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2061503752541173596, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8804356776891954089}
-  m_SourcePrefab: {fileID: 100100000, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
---- !u!114 &100349873776821649 stripped
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+--- !u!224 &4114598748571305697 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+  m_PrefabInstance: {fileID: 5622923996206582146}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7459046754092653327 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6073775282054641087, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-  m_PrefabInstance: {fileID: 6138091685345964078}
+  m_CorrespondingSourceObject: {fileID: 2993618411261579917, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+  m_PrefabInstance: {fileID: 5622923996206582146}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -3065,41 +3234,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &1987905680089800220 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-  m_PrefabInstance: {fileID: 6138091685345964078}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &4886482520565110457 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1656942219936097943, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-  m_PrefabInstance: {fileID: 6138091685345964078}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5311168242667669362}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &5311168242667669362 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2061503752541173596, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-  m_PrefabInstance: {fileID: 6138091685345964078}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8804356776891954089
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5311168242667669362}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 48a99fe6f98fe774dafa3ddf0d490f6d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  graphic: {fileID: 4886482520565110457}
-  type: 3
 --- !u!1001 &6558169836456642145
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Treasure/TDK/ConnectInternal/Prefabs/Modals/Landscape/TransitionModal Landscape.prefab
+++ b/Assets/Treasure/TDK/ConnectInternal/Prefabs/Modals/Landscape/TransitionModal Landscape.prefab
@@ -273,7 +273,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Verifying identity through browser
+  m_text: Authenticating...
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: c4ea218dd51bc52448c157e5d9e720e1, type: 2}
   m_sharedMaterial: {fileID: -6057154001904965228, guid: c4ea218dd51bc52448c157e5d9e720e1, type: 2}
@@ -421,7 +421,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: This might take a few seconds...
+  m_text: Sign into your account in the pop-up
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: c4ea218dd51bc52448c157e5d9e720e1, type: 2}
   m_sharedMaterial: {fileID: -6057154001904965228, guid: c4ea218dd51bc52448c157e5d9e720e1, type: 2}

--- a/Assets/Treasure/TDK/ConnectInternal/Prefabs/Modals/Portait/ConfirmLoginModal Portrait.prefab
+++ b/Assets/Treasure/TDK/ConnectInternal/Prefabs/Modals/Portait/ConfirmLoginModal Portrait.prefab
@@ -126,7 +126,8 @@ RectTransform:
   - {fileID: 3109663002690644301}
   - {fileID: 999852633057712117}
   - {fileID: 6749950793435910166}
-  - {fileID: 5424402388504598717}
+  - {fileID: 7849459300799437476}
+  - {fileID: 2071334302658457069}
   - {fileID: 8413091361053074250}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -189,11 +190,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   modalRect: {fileID: 3209660051194142649}
   animeTime: 0.3
-  appSettingsData: {fileID: 11400000, guid: 7a33cadc2364fa345bf7da0758bc668d, type: 2}
   infoText: {fileID: 7362927454854189632}
   confirmationInputCodeHolder: {fileID: 3976814896336013177}
   confirmCode: {fileID: 8094669276200243857}
-  didntReceiveEmailButton: {fileID: 5887804748187960112}
+  goBackButton: {fileID: 4766213380365938691}
   codeInput: {fileID: 9173071958882861056}
   errorText: {fileID: 8016570992206528793}
   keyBoardSpace: {fileID: 5077771976336199432}
@@ -1459,6 +1459,155 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!1 &7519258449903434010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7849459300799437476}
+  - component: {fileID: 8204188497514579760}
+  - component: {fileID: 1426511101986232557}
+  - component: {fileID: 2807550393413445020}
+  m_Layer: 5
+  m_Name: LabelText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7849459300799437476
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7519258449903434010}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3209660051194142649}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8204188497514579760
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7519258449903434010}
+  m_CullTransparentMesh: 1
+--- !u!114 &1426511101986232557
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7519258449903434010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "Haven\u2019t received an email?"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: c4ea218dd51bc52448c157e5d9e720e1, type: 2}
+  m_sharedMaterial: {fileID: -6057154001904965228, guid: c4ea218dd51bc52448c157e5d9e720e1, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4286411888
+  m_fontColor: {r: 0.4392157, g: 0.45490196, b: 0.49019608, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &2807550393413445020
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7519258449903434010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48a99fe6f98fe774dafa3ddf0d490f6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 1426511101986232557}
+  type: 3
 --- !u!1 &7553392668189722510
 GameObject:
   m_ObjectHideFlags: 0
@@ -1973,248 +2122,6 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 3566897008179783358, guid: ef6a783d005f56e418addd6bb02946cf, type: 3}
   m_PrefabInstance: {fileID: 78361026628771024}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &432289804528400015
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 3209660051194142649}
-    m_Modifications:
-    - target: {fileID: 780174145562233051, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1656942219936097943, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_text
-      value: "Haven\u2019t received an email?"
-      objectReference: {fileID: 0}
-    - target: {fileID: 1656942219936097943, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_fontColor.b
-      value: 0.49019608
-      objectReference: {fileID: 0}
-    - target: {fileID: 1656942219936097943, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_fontColor.g
-      value: 0.45490196
-      objectReference: {fileID: 0}
-    - target: {fileID: 1656942219936097943, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_fontColor.r
-      value: 0.4392157
-      objectReference: {fileID: 0}
-    - target: {fileID: 1656942219936097943, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4286411888
-      objectReference: {fileID: 0}
-    - target: {fileID: 3586646965343017848, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3586646965343017848, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3586646965343017848, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3586646965343017848, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3586646965343017848, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3586646965343017848, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6073775282054641087, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_TargetGraphic
-      value: 
-      objectReference: {fileID: 1369491635591925784}
-    - target: {fileID: 6255446114179569223, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_PreferredHeight
-      value: 24
-      objectReference: {fileID: 0}
-    - target: {fileID: 6843762273644054300, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_Name
-      value: TextButton(DidntReceiveEmail)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7430015229592980691, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_Color.a
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7430015229592980691, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_Color.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7430015229592980691, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_Color.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7430015229592980691, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9207731092786971527, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9207731092786971527, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9207731092786971527, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 9207731092786971527, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 9207731092786971527, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 158.02002
-      objectReference: {fileID: 0}
-    - target: {fileID: 9207731092786971527, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -22
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2061503752541173596, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3663371349905285391}
-  m_SourcePrefab: {fileID: 100100000, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
---- !u!114 &1369491635591925784 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1656942219936097943, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-  m_PrefabInstance: {fileID: 432289804528400015}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1829626883653353939}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &1829626883653353939 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2061503752541173596, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-  m_PrefabInstance: {fileID: 432289804528400015}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &3663371349905285391
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1829626883653353939}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 48a99fe6f98fe774dafa3ddf0d490f6d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  graphic: {fileID: 1369491635591925784}
-  type: 3
---- !u!224 &5424402388504598717 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5672446951835627058, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-  m_PrefabInstance: {fileID: 432289804528400015}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &5887804748187960112 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6073775282054641087, guid: 8cda3cd0a9d577d47b2f4fd8bd1fb222, type: 3}
-  m_PrefabInstance: {fileID: 432289804528400015}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &2602069729342727982
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2744,6 +2651,232 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 3566897008179783358, guid: ef6a783d005f56e418addd6bb02946cf, type: 3}
   m_PrefabInstance: {fileID: 5009491580585754486}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7759567762665251470
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3209660051194142649}
+    m_Modifications:
+    - target: {fileID: 2131894008028889035, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_FlexibleWidth
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2131894008028889035, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 44
+      objectReference: {fileID: 0}
+    - target: {fileID: 2131894008028889035, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_PreferredHeight
+      value: 44
+      objectReference: {fileID: 0}
+    - target: {fileID: 2862594196186656857, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2862594196186656857, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2862594196186656857, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2862594196186656857, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2862594196186656857, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2862594196186656857, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3824770152328208627, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 3ec3c9de874d61740baef964614f2710, type: 3}
+    - target: {fileID: 3824770152328208627, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_Color.b
+      value: 0.6392157
+      objectReference: {fileID: 0}
+    - target: {fileID: 3824770152328208627, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_Color.g
+      value: 0.54509807
+      objectReference: {fileID: 0}
+    - target: {fileID: 3824770152328208627, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_Color.r
+      value: 0.44705883
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_text
+      value: Go Back
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontSize
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontStyle
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontColor.b
+      value: 0.6392157
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontColor.g
+      value: 0.54509807
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontColor.r
+      value: 0.44705883
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 3840563273972026306, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4288908146
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828821369071648406, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828821369071648406, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828821369071648406, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828821369071648406, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828821369071648406, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828821369071648406, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8225361491217918181, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_Name
+      value: Button(Back)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554024243294804342, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_ChildAlignment
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 4222676951430765326, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+--- !u!224 &2071334302658457069 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8579742489671749475, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+  m_PrefabInstance: {fileID: 7759567762665251470}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4766213380365938691 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2993618411261579917, guid: e23b01b46f7753141acbbae60bfdf8e1, type: 3}
+  m_PrefabInstance: {fileID: 7759567762665251470}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &7817090945350204638
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Treasure/TDK/ConnectInternal/Prefabs/Modals/Portait/TransitionModal Portrait.prefab
+++ b/Assets/Treasure/TDK/ConnectInternal/Prefabs/Modals/Portait/TransitionModal Portrait.prefab
@@ -163,7 +163,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: This might take a few seconds...
+  m_text: Sign into your account in the pop-up
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: c4ea218dd51bc52448c157e5d9e720e1, type: 2}
   m_sharedMaterial: {fileID: -6057154001904965228, guid: c4ea218dd51bc52448c157e5d9e720e1, type: 2}
@@ -298,7 +298,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Verifying identity through browser
+  m_text: Authenticating...
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: c4ea218dd51bc52448c157e5d9e720e1, type: 2}
   m_sharedMaterial: {fileID: -6057154001904965228, guid: c4ea218dd51bc52448c157e5d9e720e1, type: 2}

--- a/Assets/Treasure/TDK/Runtime/Connect/Modals/ConfirmLoginModal.cs
+++ b/Assets/Treasure/TDK/Runtime/Connect/Modals/ConfirmLoginModal.cs
@@ -14,7 +14,7 @@ namespace Treasure
         [SerializeField] private GameObject confirmationInputCodeHolder;
         [Space]
         [SerializeField] private Button confirmCode;
-        [SerializeField] private Button didntReceiveEmailButton;
+        [SerializeField] private Button goBackButton;
         [Space]
         [SerializeField] private TMP_InputField codeInput;
         [SerializeField] private TMP_Text errorText;
@@ -29,7 +29,7 @@ namespace Treasure
             codeInput.onSelect.AddListener(value => SetKeyboardSpace(true));
             codeInput.onDeselect.AddListener(value => SetKeyboardSpace(false));
 
-            didntReceiveEmailButton.onClick.AddListener(() =>
+            goBackButton.onClick.AddListener(() =>
             {
                 _ = TDK.Connect.Disconnect();
                 TDKConnectUIManager.Instance.ShowLoginModal();

--- a/Assets/Treasure/TDK/Runtime/Connect/Modals/TransitionModal.cs
+++ b/Assets/Treasure/TDK/Runtime/Connect/Modals/TransitionModal.cs
@@ -5,7 +5,6 @@ using UnityEngine.UI;
 
 namespace Treasure
 {
-    // TODO reword in a way that prompts user to take action ("Sign into your account in the pop-up/browser"?)
     public class TransitionModal : ModalBase
     {
         [Space]

--- a/Assets/Treasure/TDK/Runtime/Connect/UI/TDKConnectUIManager.cs
+++ b/Assets/Treasure/TDK/Runtime/Connect/UI/TDKConnectUIManager.cs
@@ -39,11 +39,18 @@ namespace Treasure
             });
             backGroundButton.onClick.AddListener(() =>
             {
-                if (currentModalOpended == confirmLoginModal)
+                if (TDK.AppConfig.ConnectHideBehavior == TDKConfig.ConnectUIHideBehavior.HideOnOutsideClick)
                 {
-                    return; // do not hide while waiting for user to input OTP
+                    Hide();
                 }
-                Hide();
+                else if (TDK.AppConfig.ConnectHideBehavior == TDKConfig.ConnectUIHideBehavior.DoNotHideOnOtpScreen)
+                {
+                    // do not hide while waiting for user to input OTP
+                    if (currentModalOpended != confirmLoginModal)
+                    {
+                        Hide();
+                    }
+                }
             });
         }
 

--- a/Assets/Treasure/TDK/Runtime/Connect/UI/TDKConnectUIManager.cs
+++ b/Assets/Treasure/TDK/Runtime/Connect/UI/TDKConnectUIManager.cs
@@ -39,6 +39,10 @@ namespace Treasure
             });
             backGroundButton.onClick.AddListener(() =>
             {
+                if (currentModalOpended == confirmLoginModal)
+                {
+                    return; // do not hide while waiting for user to input OTP
+                }
                 Hide();
             });
         }

--- a/Assets/Treasure/TDK/Runtime/TDKConfig.cs
+++ b/Assets/Treasure/TDK/Runtime/TDKConfig.cs
@@ -70,7 +70,10 @@ namespace Treasure
 
         [SerializeField] private ScriptableObjectDictionary moduleConfigurations = null;
 
+        public enum ConnectUIHideBehavior { HideOnOutsideClick, DoNotHideOnOtpScreen, NeverHide }
+
         [Header("Misc")]
+        [SerializeField] private ConnectUIHideBehavior _connectHideBehavior = ConnectUIHideBehavior.DoNotHideOnOtpScreen;
         [SerializeField] private LoggerLevelValue _devLoggerLevel = LoggerLevelValue.INFO;
         [SerializeField] private LoggerLevelValue _prodLoggerLevel = LoggerLevelValue.INFO;
         [SerializeField] private bool _autoInitialize = true;
@@ -106,6 +109,11 @@ namespace Treasure
             set { if (Environment == Env.DEV) _devLoggerLevel = value; else _prodLoggerLevel = value; }
         }
 
+        public ConnectUIHideBehavior ConnectHideBehavior
+        {
+            get { return _connectHideBehavior; }
+            set { _connectHideBehavior = value; }
+        }
         public string ApiKey => Environment == Env.DEV ? _general._devApiKey : _general._prodApiKey;
 
         public bool AutoInitialize => _autoInitialize;


### PR DESCRIPTION
- Replace text button by explicit Go Back button

I left the "Haven't received an email" text but its not clickable anymore, the intention is to click the "Go back" button below in that case.

I like that there is also now more space between the "Confirm" button and the button to go back. Previously it was much more likely to misclick it specially on mobile

<img width="330" alt="image" src="https://github.com/user-attachments/assets/1bb4e5f5-0597-4741-a6a6-4b0573fae41e">
