### PR TITLE
Keep previous session options if not provided in new tdk config [ENG-754]

### DIFF
--- a/Assets/TestsBasic/AnalyticsTest.cs
+++ b/Assets/TestsBasic/AnalyticsTest.cs
@@ -180,7 +180,7 @@ public class AnalyticsTest
                 devDefaultChainIdentifier = "arbitrum-sepolia",
                 prodDefaultChainIdentifier = "arbitrum"
             },
-        });
+        }, null);
         
         testTDKAbstractedEngineApi = new TestTDKAbstractedEngineApi();
 

--- a/Assets/Treasure/TDK/Editor/TDKConfigEditor.cs
+++ b/Assets/Treasure/TDK/Editor/TDKConfigEditor.cs
@@ -29,10 +29,10 @@ namespace Treasure
             CheckForAndCreateResourcesDir(TDKConfig.DEFAULT_CONFIG_LOCATION);
 
             var config = ScriptableObject.CreateInstance<TDKConfig>();
-            var previousConfig = TDKConfig.LoadFromResources();
 
             if(serializedConfig != null)
             {
+                var previousConfig = TDKConfig.LoadFromResources();
                 config.SetConfig(serializedConfig, previousConfig);
             }
 

--- a/Assets/Treasure/TDK/Editor/TDKConfigEditor.cs
+++ b/Assets/Treasure/TDK/Editor/TDKConfigEditor.cs
@@ -29,10 +29,11 @@ namespace Treasure
             CheckForAndCreateResourcesDir(TDKConfig.DEFAULT_CONFIG_LOCATION);
 
             var config = ScriptableObject.CreateInstance<TDKConfig>();
+            var previousConfig = TDKConfig.LoadFromResources();
 
             if(serializedConfig != null)
             {
-                config.SetConfig(serializedConfig);
+                config.SetConfig(serializedConfig, previousConfig);
             }
 
             AssetDatabase.CreateAsset(config, TDKConfig.DEFAULT_CONFIG_LOCATION + "/TDKConfig.asset");

--- a/Assets/Treasure/TDK/Runtime/TDKConfig.cs
+++ b/Assets/Treasure/TDK/Runtime/TDKConfig.cs
@@ -165,13 +165,14 @@ namespace Treasure
             return Resources.Load<TDKConfig>("TDKConfig");
         }
 
-        public void SetConfig(SerializedTDKConfig config)
+        public void SetConfig(SerializedTDKConfig config, TDKConfig previousConfig)
         {
             // General
             _general = new GeneralConfig
             {
                 _cartridgeTag = config.general.cartridgeTag,
                 _cartridgeName = config.general.cartridgeName,
+                _cartridgeIcon = previousConfig != null ? previousConfig._general._cartridgeIcon : null,
                 _devApiUrl = config.general.devApiUrl,
                 _prodApiUrl = config.general.prodApiUrl,
                 _devApiKey = config.general.devApiKey,
@@ -199,7 +200,7 @@ namespace Treasure
                 _sessionMinDurationLeftSec = config.connect.sessionMinDurationLeftSec,
             };
 
-            if (config.connect.sessionOptions != null)
+            if (config.connect.sessionOptions?.Count > 0)
             {
                 _connect._sessionOptions = config.connect.sessionOptions.ConvertAll(option => new SessionOption
                 {
@@ -208,6 +209,10 @@ namespace Treasure
                     callTargets = option.callTargets,
                     nativeTokenLimitPerTransaction = option.nativeTokenLimitPerTransaction,
                 });
+            }
+            else if (previousConfig != null)
+            {
+                _connect._sessionOptions = previousConfig._connect._sessionOptions;
             }
             else
             {


### PR DESCRIPTION
Passing null, [], or omitting the `sessionOptions` key will keep the value from the previous TDKConfig (if any)