### PR TITLE
ci: disable create package workflow on main branch push

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,11 +1,6 @@
 name: Create Unity Package
-
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -38,7 +33,7 @@ jobs:
       - name: Create unitypackage
         uses: pCYSl5EDgo/create-unitypackage@b5c57408698b1fab8b3a84d4b67f767b8b7c0be9 # v1.2.3
         with:
-          package-path: 'out/tdk-unity_${{steps.version.outputs.TAG_NAME}}_Full.unitypackage'
+          package-path: "out/tdk-unity_${{steps.version.outputs.TAG_NAME}}_Full.unitypackage"
           include-files: metaList
       - name: Upload unitypackage artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -2,4 +2,19 @@
 
 The Treasure Development Kit streamlines client-side integration with the Treasure stack.
 
+## Usage
+
 Please refer to our [official documentation portal](https://docs.treasure.lol/tdk/unity/getting-started) for comprehensive installation, setup and integration details.
+
+## Development
+
+Download [Unity Hub and Unity](https://unity.com/download), set to editor version `2022.3.30f1`.
+
+From the menu bar, select Treasure > TDK > Config and enter the initial configuration JSON provided by the Treasure team. To make manual edits after initial import, select Treasure > Edit Config.
+
+## Deployment
+
+1. Increment the build version in [TDKVersion.cs](./Assets/Treasure/TDK/Runtime/TDKVersion.cs) according to [Semantic Versioning notation](https://semver.org/)
+2. Confirm that all third-party library versions have been updated in [versions.txt](./versions.txt).
+3. Run the "Create Unity Package" workflow in GitHub Actions to create a new release with the package attached.
+4. Update the release notes and publish.


### PR DESCRIPTION
Disables the "Create Unity Package" workflow from running on every push to the `main` branch as we move towards a trunk-based git strategy. The manual trigger is still in place