### PR TITLE
replace references to deprecated fields on user object

### DIFF
--- a/Assets/Treasure/TDK/Runtime/API/Auth.cs
+++ b/Assets/Treasure/TDK/Runtime/API/Auth.cs
@@ -56,7 +56,7 @@ namespace Treasure
     [Serializable]
     public struct User
     {
-        public struct Signer
+        public struct Session
         {
             public bool isAdmin;
             public string signer;
@@ -67,9 +67,9 @@ namespace Treasure
         }
 
         public string id;
-        public string smartAccountAddress;
+        public string address;
         public string email;
-        public List<Signer> allActiveSigners;
+        public List<Session> sessions;
     }
 
     public partial class API

--- a/Assets/Treasure/TDK/Runtime/Utils/TreasureLauncherUtils.cs
+++ b/Assets/Treasure/TDK/Runtime/Utils/TreasureLauncherUtils.cs
@@ -7,7 +7,7 @@ namespace Treasure
     public class TreasureLauncherUtils
     {
         private static bool hasParsedCommandLineArgs = false;
-        
+
         private static string tdkAuthToken = null;
 
         public static string GetLauncherAuthToken()
@@ -21,7 +21,7 @@ namespace Treasure
             // TODO check token expiration date?
             var content = GetLauncherAuthToken().Split('.')[1];
             var jsonPayload = Decode(content);
-            return JsonConvert.DeserializeObject<JToken>(jsonPayload)["ctx"]["smartAccountAddress"].ToString();
+            return JsonConvert.DeserializeObject<JToken>(jsonPayload)["ctx"]["address"].ToString();
         }
 
         private static void ParseArgs()


### PR DESCRIPTION
- Replaces references to deprecated fields on the user object, namely `smartAccountAddress` -> `address` and `allActiveSigners` -> `sessions`
- Updates method and variable names to better match other TDK nomenclature, namely replacing "signer" with "session"