### PR TITLE
Prevent social login timeout reopening connect modal after it was closed

### DIFF
--- a/Assets/Treasure/TDK/Runtime/Connect/Modals/LoginModal.cs
+++ b/Assets/Treasure/TDK/Runtime/Connect/Modals/LoginModal.cs
@@ -95,9 +95,9 @@ namespace Treasure
                 return;
             }
 
+            var transitionModal = TDKConnectUIManager.Instance.ShowTransitionModal();
             try
             {
-                var transitionModal = TDKConnectUIManager.Instance.ShowTransitionModal();
                 transitionModal.SetCancelAction(() => TDKConnectUIManager.Instance.ShowLoginModal());
                 await TDK.Connect.Disconnect(); // clean up any previous connection attempts
                 await TDK.Connect.ConnectSocial(provider);
@@ -107,10 +107,13 @@ namespace Treasure
                 if (ex.Message != "New connection attempt has been made")
                 {
                     TDKLogger.LogException($"[LoginModal:ConnectSocial] Error connecting", ex);
-                    // close TransitionModal, go back to login modal and show cause of error
-                    TDKConnectUIManager.Instance.ShowLoginModal();
-                    socialsErrorText.text = ex.Message;
-                    socialsErrorText.gameObject.SetActive(true);
+                    if (transitionModal.gameObject.activeInHierarchy) // if transition modal is still open
+                    {
+                        // close TransitionModal, go back to login modal and show cause of error
+                        TDKConnectUIManager.Instance.ShowLoginModal();
+                        socialsErrorText.text = ex.Message;
+                        socialsErrorText.gameObject.SetActive(true);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Without fix:
- open connect modal
- click google login (for example), but dont confirm the account
- click out of connect modal to close it
- wait for timeout
- result: when the timeout occurs, the login modal is forcefully opened

With the fix, a timeout or any other error wont force the login modal to reappear. Instead the error will be silently logged and ignored in the background.