### PR TITLE
Use fallback for bundleId when Application.identifier is an empty string

### DIFF
--- a/Assets/Treasure/TDK/Runtime/Services/Thirdweb/TDKThirdwebService.cs
+++ b/Assets/Treasure/TDK/Runtime/Services/Thirdweb/TDKThirdwebService.cs
@@ -44,7 +44,7 @@ namespace Treasure
 
             var clientId = TDK.AppConfig.ClientId;
 
-            bundleId ??= Application.identifier ?? $"com.{Application.companyName}.{Application.productName}";
+            bundleId = !string.IsNullOrEmpty(Application.identifier) ? Application.identifier : $"com.{Application.companyName}.{Application.productName}";
 
             Client = ThirdwebClient.Create(
                 clientId: clientId,


### PR DESCRIPTION
For some reason Application.identifier has a value of `""` in a windows build, which is not valid for configuring the thirdweb SDK